### PR TITLE
Add OpenAI-compatible vision backend for photo intake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Shelf are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **Photo Intake — OpenAI-compatible backend** — a third vision provider that
+  targets any OpenAI Chat Completions endpoint (OpenAI, OpenRouter, or a local
+  server such as vLLM / LM Studio / LocalAI) via a configurable base URL, API
+  key, and model. Reuses the existing tiling and dedup pipeline.
+
 ## [0.1.0] - 2026-07-05
 
 First public release.

--- a/DOCKERHUB_README.md
+++ b/DOCKERHUB_README.md
@@ -100,7 +100,7 @@ data/
 ### Scanning and Cataloging
 - **Camera barcode scanning** on mobile — tap to scan ISBNs and UPCs
 - **USB/Bluetooth scanner support** — works with any scanner that sends Enter after the barcode
-- **Photo intake** — bulk-add books from a photo of your shelves; a vision model (Anthropic API or fully local Ollama) reads the spines and you confirm before import
+- **Photo intake** — bulk-add books from a photo of your shelves; a vision model (Anthropic API, any OpenAI-compatible endpoint, or fully local Ollama) reads the spines and you confirm before import
 - **Title search** — search Open Library, TMDb, or IGDB by title when you don't have a barcode
 - **Cascading metadata lookup** — Open Library, Hardcover, Google Books, and more
 - **Cover art pipeline** — automatically fetches covers from multiple sources with manual upload fallback
@@ -153,7 +153,9 @@ Shelf works fully out of the box with no API keys. These optional integrations a
 | [IGDB](https://dev.twitch.tv/console) (Twitch) | Video game metadata, cover art, platform info | Yes |
 | [TMDb](https://www.themoviedb.org) | DVD/Blu-ray metadata from UPC barcodes | Yes |
 | [ISBNdb](https://isbndb.com) | Collection valuation with market prices | Paid |
-| [Anthropic](https://console.anthropic.com) | Photo Intake spine recognition (or use a local Ollama model — free) | Pay-per-use |
+| [Anthropic](https://console.anthropic.com) | Photo Intake spine recognition (best accuracy) | Pay-per-use |
+| [OpenAI-compatible](https://platform.openai.com) | Photo Intake via any OpenAI Chat Completions endpoint (OpenAI, OpenRouter, vLLM, LM Studio…) | Pay-per-use / free |
+| [Ollama](https://ollama.com) | Photo Intake with a fully local vision model | Free |
 
 ## Updating
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A self-hosted home library catalog with barcode scanning, multi-mode scanning wo
 Most home library apps are cloud-hosted, mobile-only, or require you to manually enter every book. Shelf takes a different approach:
 
 - **Scan and done** — point your phone camera at a barcode or use a USB/Bluetooth barcode scanner and the book is cataloged in seconds, complete with cover art, author, series info, and description. Works out of the box with any scanner that sends Enter after the barcode (most do by default)
-- **Bulk-add from a photo** — snap a picture of a full shelf and a vision model reads the spines. Review the detected titles, then import them all with full metadata and covers. Works with the Anthropic API or a fully local Ollama model
+- **Bulk-add from a photo** — snap a picture of a full shelf and a vision model reads the spines. Review the detected titles, then import them all with full metadata and covers. Works with the Anthropic API, any OpenAI-compatible endpoint, or a fully local Ollama model
 - **8 scan modes** — Add, Wishlist, Lend, Return, Move, Inventory, Lookup, and Quick Rate. The scan tab adapts to whatever you're doing: adding new items, lending to a friend, reorganizing shelves, or auditing a room
 - **Title search** — don't have a barcode? Search by title across Open Library (books), TMDb (movies), and IGDB (video games) and add directly from results
 - **Zero cloud dependency** — runs entirely on your network in a single Docker container with a SQLite database. Your data never leaves your home
@@ -128,6 +128,9 @@ cover art, and an author-match guard keeps wrong editions from slipping in.
 Configure a vision backend under Settings → Integrations → Photo Intake:
 
 - **Anthropic API** — best accuracy; pay-per-photo (typically a few cents)
+- **OpenAI-compatible** — any endpoint that speaks the OpenAI Chat Completions
+  API: OpenAI itself, OpenRouter, or a local server (vLLM, LM Studio, LocalAI).
+  Set the base URL, an optional API key, and a vision-capable model
 - **Ollama** — free and fully local with any vision-capable model
   (gemma3, qwen2.5vl, llama3.2-vision, …); accuracy depends on the model
 
@@ -239,7 +242,9 @@ Configure in Settings to unlock additional features:
 | **IGDB** (Twitch) | Video game metadata, cover art, and platform info | [dev.twitch.tv/console](https://dev.twitch.tv/console) |
 | **ISBNdb** | Collection valuation with market prices | [isbndb.com](https://isbndb.com) |
 | **TMDb** | DVD/Blu-ray metadata and title search via UPC barcode | [themoviedb.org](https://www.themoviedb.org) |
-| **Anthropic** | Photo Intake spine recognition (or use a local Ollama model — no key needed) | [console.anthropic.com](https://console.anthropic.com) |
+| **Anthropic** | Photo Intake spine recognition (best accuracy) | [console.anthropic.com](https://console.anthropic.com) |
+| **OpenAI-compatible** | Photo Intake via any OpenAI Chat Completions endpoint (OpenAI, OpenRouter, vLLM, LM Studio…) | [platform.openai.com](https://platform.openai.com) |
+| **Ollama** | Photo Intake with a fully local vision model — no key needed | [ollama.com](https://ollama.com) |
 
 ## Development
 

--- a/app/config.py
+++ b/app/config.py
@@ -59,6 +59,9 @@ ANTHROPIC_HIGHRES_MODELS = ("opus-4-7", "opus-4-8", "sonnet-5", "fable-5")
 ANTHROPIC_HIGHRES_CAP = {"long_edge": 2576, "max_pixels": 3_750_000}
 ANTHROPIC_STANDARD_CAP = {"long_edge": 1568, "max_pixels": 1_150_000}
 OLLAMA_DEFAULT_INGEST_LONG_EDGE = 1024  # gemma3 crops at 896px; qwen2.5vl is dynamic
+# OpenAI-compatible endpoints downscale to ~2048px on the long edge for
+# high-detail vision. Operator-tunable since compatible servers vary.
+OPENAI_DEFAULT_INGEST_LONG_EDGE = 2048
 
 # Downscale factor at or above which the "what the model sees" preview and
 # the tiling offer appear. Below it the single-image path runs unchanged.

--- a/app/crypto.py
+++ b/app/crypto.py
@@ -38,6 +38,7 @@ SENSITIVE_KEYS: frozenset[str] = frozenset(
     {
         "abs_token",
         "anthropic_api_key",
+        "openai_api_key",
         "hardcover_token",
         "isbndb_api_key",
         "tmdb_api_key",

--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -63,31 +63,46 @@ async def update_vision_settings(
     vision_provider: str = Form(""),
     anthropic_api_key: str = Form(""),
     anthropic_vision_model: str = Form(""),
+    openai_base_url: str = Form(""),
+    openai_api_key: str = Form(""),
+    openai_vision_model: str = Form(""),
+    openai_ingest_long_edge: str = Form(""),
     ollama_url: str = Form(""),
     ollama_model: str = Form(""),
     ollama_ingest_long_edge: str = Form(""),
     clear_anthropic_api_key: str = Form(""),
+    clear_openai_api_key: str = Form(""),
 ):
     """Save photo-intake vision settings.
 
     Separate handler (like /lending) so this partial form doesn't blank
     the other integration credentials.
     """
-    if vision_provider not in ("", "anthropic", "ollama"):
+    if vision_provider not in ("", "anthropic", "openai", "ollama"):
         return {"ok": False, "message": "Unknown vision provider"}
-    long_edge = ollama_ingest_long_edge.strip()
-    if long_edge and not long_edge.isdigit():
+    ollama_long_edge = ollama_ingest_long_edge.strip()
+    if ollama_long_edge and not ollama_long_edge.isdigit():
         return {"ok": False, "message": "Ollama image size must be a whole number of pixels"}
+    openai_long_edge = openai_ingest_long_edge.strip()
+    if openai_long_edge and not openai_long_edge.isdigit():
+        return {"ok": False, "message": "OpenAI image size must be a whole number of pixels"}
+    # Each API key clears independently via its own checkbox.
+    clears = {"anthropic_api_key": clear_anthropic_api_key == "on",
+              "openai_api_key": clear_openai_api_key == "on"}
     with get_db() as db:
         for key, value in [
             ("vision_provider", vision_provider),
             ("anthropic_api_key", anthropic_api_key.strip()),
             ("anthropic_vision_model", anthropic_vision_model.strip()),
+            ("openai_base_url", openai_base_url.strip().rstrip("/")),
+            ("openai_api_key", openai_api_key.strip()),
+            ("openai_vision_model", openai_vision_model.strip()),
+            ("openai_ingest_long_edge", openai_long_edge),
             ("ollama_url", ollama_url.strip().rstrip("/")),
             ("ollama_model", ollama_model.strip()),
-            ("ollama_ingest_long_edge", long_edge),
+            ("ollama_ingest_long_edge", ollama_long_edge),
         ]:
-            _upsert_setting(db, key, value, cleared=clear_anthropic_api_key == "on" and key == "anthropic_api_key")
+            _upsert_setting(db, key, value, cleared=clears.get(key, False))
     return RedirectResponse(url="/settings", status_code=303)
 
 

--- a/app/services/tiling.py
+++ b/app/services/tiling.py
@@ -20,6 +20,7 @@ from app.config import (
     EXPECTED_BOOKS_PER_MEGAPIXEL,
     IMAGE_TOKEN_DIVISOR,
     OLLAMA_DEFAULT_INGEST_LONG_EDGE,
+    OPENAI_DEFAULT_INGEST_LONG_EDGE,
     PROMPT_OVERHEAD_TOKENS,
     TILE_OVERLAP_X,
     TILE_OVERLAP_Y,
@@ -48,6 +49,11 @@ def ingest_cap(settings: dict) -> dict:
         if any(m in model for m in ANTHROPIC_HIGHRES_MODELS):
             return dict(ANTHROPIC_HIGHRES_CAP)
         return dict(ANTHROPIC_STANDARD_CAP)
+    if provider == "openai":
+        # OpenAI-compatible endpoints downscale on their side; the knob is the
+        # effective long edge the model sees, so tiling kicks in above it.
+        long_edge = int(settings.get("openai_ingest_long_edge") or OPENAI_DEFAULT_INGEST_LONG_EDGE)
+        return {"long_edge": long_edge, "max_pixels": long_edge * long_edge}
     # Ollama: we control resolution entirely; treat the knob as the long edge
     long_edge = int(settings.get("ollama_ingest_long_edge") or OLLAMA_DEFAULT_INGEST_LONG_EDGE)
     return {"long_edge": long_edge, "max_pixels": long_edge * long_edge}
@@ -146,7 +152,12 @@ def expected_books(width: int, height: int) -> int:
 
 
 def estimate_cost_usd(images_dims: list[tuple[int, int]], settings: dict, books: int) -> float | None:
-    """Estimated dollars for one analyze call. None for local providers (free)."""
+    """Estimated dollars for one analyze call.
+
+    None when a price can't be pinned down: local Ollama (free), and
+    OpenAI-compatible endpoints whose model/pricing vary by provider (OpenAI,
+    Azure, OpenRouter, self-hosted). The UI simply omits the estimate then.
+    """
     if (settings.get("vision_provider") or "") != "anthropic":
         return None
     model = settings.get("anthropic_vision_model") or DEFAULT_ANTHROPIC_MODEL

--- a/app/services/vision.py
+++ b/app/services/vision.py
@@ -1,17 +1,20 @@
 """Vision-based shelf-photo intake: read book spines from a photo.
 
-Two backends, selected by the `vision_provider` setting:
+Three backends, selected by the `vision_provider` setting:
 - "anthropic": Claude vision via the official SDK (best spine accuracy).
+- "openai": any OpenAI-compatible chat-completions endpoint (OpenAI itself,
+  Azure OpenAI, OpenRouter, or a local server like vLLM / LM Studio / LocalAI).
+  The base URL is configurable, so this one branch covers the whole family.
 - "ollama": local model via the Ollama REST API (free, private, needs a
   vision-capable model such as gemma3).
 
-Both return the same shape: a list of {"title": str, "authors": str|None}.
+All return the same shape: a list of {"title": str, "authors": str|None}.
 
 Input is a list of (bytes, mime) images. A single image is the normal path;
 multiple images are overlapping tiles of one photo (see services/tiling.py).
-For Anthropic up to MAX_TILES_PER_REQUEST tiles go in one request as multiple
-image blocks (the model merges overlap duplicates); beyond that, and always
-for Ollama, tiles are analyzed one call at a time and merged in code.
+For Anthropic and OpenAI up to MAX_TILES_PER_REQUEST tiles go in one request as
+multiple image blocks (the model merges overlap duplicates); beyond that, and
+always for Ollama, tiles are analyzed one call at a time and merged in code.
 """
 
 import base64
@@ -27,6 +30,8 @@ from app.config import MAX_TILES_PER_REQUEST
 logger = logging.getLogger(__name__)
 
 DEFAULT_ANTHROPIC_MODEL = "claude-opus-4-8"
+DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
+DEFAULT_OPENAI_MODEL = "gpt-4o-mini"
 DEFAULT_OLLAMA_URL = "http://localhost:11434"
 DEFAULT_OLLAMA_MODEL = "gemma3:12b"
 
@@ -47,6 +52,13 @@ TILED_PROMPT_SUFFIX = (
     "ordered left-to-right then top-to-bottom. Adjacent tiles share an "
     "overlap region, so the same spine may appear in two tiles — merge such "
     "duplicates and list each distinct book exactly once."
+)
+
+# Appended for providers without a schema-enforced output mode (Ollama, and
+# OpenAI-compatible endpoints run in JSON-object mode). The word "JSON" here
+# also satisfies OpenAI's requirement when response_format is json_object.
+JSON_ONLY_SUFFIX = (
+    ' Respond with JSON only: {"books": [{"title": "...", "authors": "... or null"}]}'
 )
 
 # Fuzzy-title similarity at or above which two tile results are the same book
@@ -159,6 +171,14 @@ async def detect_spines(images: list[tuple[bytes, str]], settings: dict) -> list
             return merge_tile_books([books]) if len(images) > 1 else books
         results = [await _detect_anthropic([img], settings) for img in images]
         return merge_tile_books(results)
+    if provider == "openai":
+        if len(images) <= MAX_TILES_PER_REQUEST:
+            books = await _detect_openai(images, settings)
+            # The prompt asks the model to merge overlap duplicates; sweep
+            # once more in code to catch the ones it misses.
+            return merge_tile_books([books]) if len(images) > 1 else books
+        results = [await _detect_openai([img], settings) for img in images]
+        return merge_tile_books(results)
     if provider == "ollama":
         if len(images) == 1:
             return await _detect_ollama(images[0][0], settings)
@@ -222,6 +242,62 @@ async def _detect_anthropic(images: list[tuple[bytes, str]], settings: dict) -> 
         raise VisionError("The model returned an unreadable response — try again")
 
 
+async def _detect_openai(images: list[tuple[bytes, str]], settings: dict) -> list[dict]:
+    """Read spines via an OpenAI-compatible /chat/completions endpoint.
+
+    Uses httpx directly (no SDK) so any compatible server works and respx can
+    mock it in tests. Structured output is requested via response_format
+    json_object plus an explicit JSON instruction in the prompt — the widely
+    supported subset, rather than json_schema which many compatible servers
+    lack.
+    """
+    api_key = settings.get("openai_api_key")
+    if not api_key:
+        raise VisionError("OpenAI API key is not configured")
+    base_url = (settings.get("openai_base_url") or DEFAULT_OPENAI_BASE_URL).rstrip("/")
+    model = settings.get("openai_vision_model") or DEFAULT_OPENAI_MODEL
+
+    content: list[dict] = [{"type": "text", "text": _prompt_for(len(images)) + JSON_ONLY_SUFFIX}]
+    for image_bytes, mime in images:
+        b64 = base64.standard_b64encode(image_bytes).decode()
+        content.append({
+            "type": "image_url",
+            "image_url": {"url": f"data:{mime};base64,{b64}"},
+        })
+
+    payload = {
+        "model": model,
+        # Classic Chat Completions field — the form every OpenAI-compatible
+        # server understands (reasoning models use max_completion_tokens, but
+        # those aren't the vision target here).
+        "max_tokens": 16000,
+        "response_format": {"type": "json_object"},
+        "messages": [{"role": "user", "content": content}],
+    }
+    headers = {"Authorization": f"Bearer {api_key}"}
+    try:
+        async with httpx.AsyncClient(timeout=300.0) as client:
+            resp = await client.post(f"{base_url}/chat/completions", json=payload, headers=headers)
+    except httpx.HTTPError:
+        raise VisionError(f"Could not reach the OpenAI API at {base_url}")
+    if resp.status_code in (401, 403):
+        raise VisionError("OpenAI API key was rejected — check it in Settings")
+    if resp.status_code != 200:
+        logger.warning("OpenAI vision call failed: HTTP %d %s", resp.status_code, resp.text[:200])
+        raise VisionError(f"OpenAI API error (HTTP {resp.status_code}) — try again")
+
+    try:
+        text = resp.json()["choices"][0]["message"]["content"] or ""
+    except (KeyError, IndexError, TypeError):
+        logger.warning("OpenAI vision returned an unexpected response shape")
+        raise VisionError("The OpenAI API returned an unexpected response — try again")
+    try:
+        return _clean(json.loads(text))
+    except json.JSONDecodeError:
+        logger.warning("OpenAI vision returned non-JSON output: %s", text[:200])
+        raise VisionError("The model returned an unreadable response — try again")
+
+
 async def _detect_ollama(image_bytes: bytes, settings: dict) -> list[dict]:
     url = (settings.get("ollama_url") or DEFAULT_OLLAMA_URL).rstrip("/")
     model = settings.get("ollama_model") or DEFAULT_OLLAMA_MODEL
@@ -232,7 +308,7 @@ async def _detect_ollama(image_bytes: bytes, settings: dict) -> list[dict]:
         "format": "json",
         "messages": [{
             "role": "user",
-            "content": PROMPT + ' Respond with JSON only: {"books": [{"title": "...", "authors": "... or null"}]}',
+            "content": PROMPT + JSON_ONLY_SUFFIX,
             "images": [base64.standard_b64encode(image_bytes).decode()],
         }],
     }

--- a/app/templates/intake.html
+++ b/app/templates/intake.html
@@ -8,7 +8,7 @@
     {% if not vision_provider %}
     <div class="bg-shelf-card rounded-xl border border-shelf-warning/30 p-6 text-sm">
         <p class="font-medium text-shelf-warning mb-1">No vision provider configured</p>
-        <p class="text-shelf-muted">Set one up under <a href="/settings" class="text-shelf-accent2 hover:text-shelf-accent">Settings &rarr; Integrations &rarr; Photo Intake</a> — either an Anthropic API key (best accuracy) or a local Ollama model (free, private).</p>
+        <p class="text-shelf-muted">Set one up under <a href="/settings" class="text-shelf-accent2 hover:text-shelf-accent">Settings &rarr; Integrations &rarr; Photo Intake</a> — an Anthropic API key (best accuracy), any OpenAI-compatible endpoint, or a local Ollama model (free, private).</p>
     </div>
     {% else %}
 
@@ -24,7 +24,7 @@
                 <span x-show="analyzing">Reading&hellip;</span>
             </button>
         </div>
-        <p class="text-xs text-shelf-muted mt-2">Provider: <span class="text-shelf-text">{{ 'Anthropic API' if vision_provider == 'anthropic' else 'Ollama (local)' }}</span> &middot; photos are analyzed in memory and not stored.</p>
+        <p class="text-xs text-shelf-muted mt-2">Provider: <span class="text-shelf-text">{{ {'anthropic': 'Anthropic API', 'openai': 'OpenAI-compatible', 'ollama': 'Ollama (local)'}.get(vision_provider, vision_provider) }}</span> &middot; photos are analyzed in memory and not stored.</p>
         <template x-if="preview">
             <img :src="preview" alt="Shelf photo preview" class="mt-4 rounded-lg max-h-64" x-show="!needsChoice">
         </template>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -782,7 +782,7 @@
     <div class="bg-shelf-card rounded-xl border border-shelf-border p-6"
          x-data="{ visionProvider: '{{ settings.get('vision_provider', '') }}' }">
         <h2 class="text-lg font-semibold mb-1">Photo Intake (Vision)</h2>
-        <p class="text-sm text-shelf-muted mb-4">Bulk-add books by photographing a shelf &mdash; a vision model reads the spines. Use the Anthropic API (best accuracy, pay per photo) or a local Ollama model (free and private, needs a vision-capable model like gemma3).</p>
+        <p class="text-sm text-shelf-muted mb-4">Bulk-add books by photographing a shelf &mdash; a vision model reads the spines. Use the Anthropic API (best accuracy, pay per photo), any OpenAI-compatible endpoint (OpenAI, OpenRouter, or a local server like vLLM / LM Studio), or a local Ollama model (free and private, needs a vision-capable model like gemma3).</p>
         <form action="/api/settings/vision" method="post" class="space-y-3">
             <div>
                 <label for="vision_provider" class="block text-sm font-medium text-shelf-muted mb-1">Provider</label>
@@ -790,6 +790,7 @@
                         class="bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-sm text-shelf-text focus:ring-2 focus:ring-shelf-accent outline-none">
                     <option value="">Disabled</option>
                     <option value="anthropic">Anthropic API</option>
+                    <option value="openai">OpenAI-compatible</option>
                     <option value="ollama">Ollama (local)</option>
                 </select>
             </div>
@@ -811,6 +812,41 @@
                     <input type="text" id="anthropic_vision_model" name="anthropic_vision_model"
                            value="{{ settings.get('anthropic_vision_model', '') }}" placeholder="claude-opus-4-8 (default)"
                            class="w-full bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-shelf-text focus:ring-2 focus:ring-shelf-accent outline-none">
+                </div>
+            </div>
+            <div x-show="visionProvider === 'openai'" class="space-y-3">
+                <div>
+                    <label for="openai_base_url" class="block text-sm font-medium text-shelf-muted mb-1">Base URL</label>
+                    <input type="text" id="openai_base_url" name="openai_base_url"
+                           value="{{ settings.get('openai_base_url', '') }}" placeholder="https://api.openai.com/v1 (default)"
+                           class="w-full bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-shelf-text focus:ring-2 focus:ring-shelf-accent outline-none">
+                    <p class="text-xs text-shelf-muted mt-1">Any OpenAI-compatible <span class="font-mono text-xs">/chat/completions</span> endpoint &mdash; OpenAI, OpenRouter, or a local server (vLLM, LM Studio, LocalAI&hellip;).</p>
+                </div>
+                <div>
+                    <label for="openai_api_key" class="block text-sm font-medium text-shelf-muted mb-1">API Key</label>
+                    <input type="password" id="openai_api_key" name="openai_api_key" autocomplete="new-password"
+                           placeholder="{% if secrets_saved['openai_api_key'] %}Saved — leave blank to keep{% else %}sk-...{% endif %}"
+                           class="w-full bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-shelf-text focus:ring-2 focus:ring-shelf-accent outline-none">
+                    <p class="text-xs text-shelf-muted mt-1">Stored encrypted; only used server-side. Local servers that need no key can leave this blank.</p>
+                    {% if secrets_saved['openai_api_key'] %}
+                    <label class="flex items-center gap-2 text-xs text-shelf-muted mt-1">
+                        <input type="checkbox" name="clear_openai_api_key" class="rounded border-shelf-border"> Remove saved key
+                    </label>
+                    {% endif %}
+                </div>
+                <div>
+                    <label for="openai_vision_model" class="block text-sm font-medium text-shelf-muted mb-1">Model</label>
+                    <input type="text" id="openai_vision_model" name="openai_vision_model"
+                           value="{{ settings.get('openai_vision_model', '') }}" placeholder="gpt-4o-mini (default)"
+                           class="w-full bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-shelf-text focus:ring-2 focus:ring-shelf-accent outline-none">
+                    <p class="text-xs text-shelf-muted mt-1">Must be a vision-capable model. Match this to whatever your endpoint serves.</p>
+                </div>
+                <div>
+                    <label for="openai_ingest_long_edge" class="block text-sm font-medium text-shelf-muted mb-1">Image size (long edge, px)</label>
+                    <input type="text" id="openai_ingest_long_edge" name="openai_ingest_long_edge" inputmode="numeric"
+                           value="{{ settings.get('openai_ingest_long_edge', '') }}" placeholder="2048 (default)"
+                           class="w-full bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-shelf-text focus:ring-2 focus:ring-shelf-accent outline-none">
+                    <p class="text-xs text-shelf-muted mt-1">Resolution the model effectively sees &mdash; drives when Photo Intake offers high-res tiling.</p>
                 </div>
             </div>
             <div x-show="visionProvider === 'ollama'" class="space-y-3">

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -10,6 +10,7 @@ from tests.conftest import _insert_item
 
 OL_SEARCH_URL = "https://openlibrary.org/search.json"
 ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
+OPENAI_URL = "https://api.openai.com/v1/chat/completions"
 OLLAMA_URL = "http://localhost:11434/api/chat"
 
 FAKE_JPEG = b"\xff\xd8\xff" + b"0" * 100
@@ -21,6 +22,17 @@ def _anthropic_response(payload: dict):
         "model": "claude-opus-4-8", "stop_reason": "end_turn", "stop_sequence": None,
         "content": [{"type": "text", "text": json.dumps(payload)}],
         "usage": {"input_tokens": 10, "output_tokens": 10},
+    })
+
+
+def _openai_response(payload: dict):
+    return httpx.Response(200, json={
+        "id": "chatcmpl_test", "object": "chat.completion", "model": "gpt-4o-mini",
+        "choices": [{
+            "index": 0, "finish_reason": "stop",
+            "message": {"role": "assistant", "content": json.dumps(payload)},
+        }],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 10, "total_tokens": 20},
     })
 
 
@@ -74,6 +86,50 @@ class TestDetectSpines:
     async def test_anthropic_without_key(self):
         with pytest.raises(vision.VisionError, match="API key"):
             await vision.detect_spines(ONE_IMAGE, {"vision_provider": "anthropic"})
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_openai_provider(self):
+        route = respx.post(OPENAI_URL).mock(return_value=_openai_response(
+            {"books": [{"title": "Dune", "authors": "Frank Herbert"}]}))
+        books = await vision.detect_spines(ONE_IMAGE, {
+            "vision_provider": "openai", "openai_api_key": "sk-test",
+        })
+        assert books == [{"title": "Dune", "authors": "Frank Herbert"}]
+        # Bearer auth + data-URI image + json_object mode
+        req = route.calls[0].request
+        assert req.headers["authorization"] == "Bearer sk-test"
+        body = json.loads(req.content)
+        assert body["response_format"] == {"type": "json_object"}
+        content = body["messages"][0]["content"]
+        img = next(b for b in content if b["type"] == "image_url")
+        assert img["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_openai_custom_base_url(self):
+        route = respx.post("http://localhost:1234/v1/chat/completions").mock(
+            return_value=_openai_response({"books": [{"title": "Dune", "authors": None}]}))
+        books = await vision.detect_spines(ONE_IMAGE, {
+            "vision_provider": "openai", "openai_api_key": "sk-test",
+            "openai_base_url": "http://localhost:1234/v1",
+        })
+        assert route.called
+        assert books == [{"title": "Dune", "authors": None}]
+
+    @pytest.mark.asyncio
+    async def test_openai_without_key(self):
+        with pytest.raises(vision.VisionError, match="API key"):
+            await vision.detect_spines(ONE_IMAGE, {"vision_provider": "openai"})
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_openai_auth_error(self):
+        respx.post(OPENAI_URL).mock(return_value=httpx.Response(401, json={"error": "bad key"}))
+        with pytest.raises(vision.VisionError, match="rejected"):
+            await vision.detect_spines(ONE_IMAGE, {
+                "vision_provider": "openai", "openai_api_key": "sk-bad",
+            })
 
     @respx.mock
     @pytest.mark.asyncio
@@ -137,6 +193,38 @@ class TestDetectSpinesTiled:
         })
         assert route.call_count == 3
         # Overlap duplicate merged; the copy with authors wins
+        assert books == [
+            {"title": "Dune", "authors": "Frank Herbert"},
+            {"title": "Solaris", "authors": "Stanislaw Lem"},
+        ]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_openai_tiles_go_in_one_request(self):
+        route = respx.post(OPENAI_URL).mock(return_value=_openai_response(
+            {"books": [{"title": "Dune", "authors": None}]}))
+        await vision.detect_spines(ONE_IMAGE * 3, {
+            "vision_provider": "openai", "openai_api_key": "sk-test",
+        })
+        assert route.call_count == 1
+        content = json.loads(route.calls[0].request.content)["messages"][0]["content"]
+        assert sum(1 for b in content if b["type"] == "image_url") == 3
+        prompt = next(b["text"] for b in content if b["type"] == "text")
+        assert "overlapping tiles" in prompt and "3 images" in prompt
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_openai_per_tile_fallback_over_cap(self, monkeypatch):
+        monkeypatch.setattr(vision, "MAX_TILES_PER_REQUEST", 2)
+        route = respx.post(OPENAI_URL).mock(side_effect=[
+            _openai_response({"books": [{"title": "Dune", "authors": "Frank Herbert"}]}),
+            _openai_response({"books": [{"title": "Dune", "authors": None}]}),
+            _openai_response({"books": [{"title": "Solaris", "authors": "Stanislaw Lem"}]}),
+        ])
+        books = await vision.detect_spines(ONE_IMAGE * 3, {
+            "vision_provider": "openai", "openai_api_key": "sk-test",
+        })
+        assert route.call_count == 3
         assert books == [
             {"title": "Dune", "authors": "Frank Herbert"},
             {"title": "Solaris", "authors": "Stanislaw Lem"},
@@ -270,6 +358,13 @@ class TestPlanEndpoint:
         self._configure(db, provider="ollama")
         data = admin_client.post("/api/intake/plan", json={"width": 6000, "height": 4000}).json()
         assert data["needs_choice"] is True
+        assert data["cost_as_is_usd"] is None
+        assert data["cost_tiled_usd"] is None
+
+    def test_openai_costs_are_null(self, admin_client, db):
+        self._configure(db, provider="openai")
+        data = admin_client.post("/api/intake/plan", json={"width": 6000, "height": 4000}).json()
+        assert data["ok"] is True
         assert data["cost_as_is_usd"] is None
         assert data["cost_tiled_usd"] is None
 

--- a/tests/test_settings_masking.py
+++ b/tests/test_settings_masking.py
@@ -120,6 +120,30 @@ class TestWriteOnlySemantics:
         with get_db() as db:
             assert get_setting(db, "anthropic_api_key") == ""
 
+    def test_openai_key_keep_and_clear(self, admin_client):
+        admin_client.post(
+            "/api/settings/vision",
+            data={"vision_provider": "openai", "openai_api_key": "sk-openai-secret"},
+            follow_redirects=False,
+        )
+        # Blank submit keeps the stored key (masked field posts empty)...
+        admin_client.post(
+            "/api/settings/vision",
+            data={"vision_provider": "openai", "openai_api_key": ""},
+            follow_redirects=False,
+        )
+        with get_db() as db:
+            assert get_setting(db, "openai_api_key") == "sk-openai-secret"
+        # ...and the OpenAI clear checkbox only clears the OpenAI key.
+        admin_client.post(
+            "/api/settings/vision",
+            data={"vision_provider": "openai", "openai_api_key": "",
+                  "clear_openai_api_key": "on"},
+            follow_redirects=False,
+        )
+        with get_db() as db:
+            assert get_setting(db, "openai_api_key") == ""
+
     def test_notify_url_keep_and_clear(self, admin_client):
         admin_client.post(
             "/api/settings/lending",

--- a/tests/test_tiling.py
+++ b/tests/test_tiling.py
@@ -48,6 +48,14 @@ class TestIngestCap:
         cap = tiling.ingest_cap({"vision_provider": "ollama", "ollama_ingest_long_edge": "896"})
         assert cap == {"long_edge": 896, "max_pixels": 896 * 896}
 
+    def test_openai_default(self):
+        cap = tiling.ingest_cap({"vision_provider": "openai"})
+        assert cap == {"long_edge": 2048, "max_pixels": 2048 * 2048}
+
+    def test_openai_setting_override(self):
+        cap = tiling.ingest_cap({"vision_provider": "openai", "openai_ingest_long_edge": "1536"})
+        assert cap == {"long_edge": 1536, "max_pixels": 1536 * 1536}
+
 
 class TestDownscaleFactor:
     def test_small_image_untouched(self):
@@ -128,6 +136,10 @@ class TestComputeGrid:
 class TestCostEstimator:
     def test_ollama_is_free(self):
         assert tiling.estimate_cost_usd([(6000, 4000)], {"vision_provider": "ollama"}, 50) is None
+
+    def test_openai_is_unestimated(self):
+        # Pricing varies across OpenAI-compatible endpoints; no estimate shown.
+        assert tiling.estimate_cost_usd([(6000, 4000)], {"vision_provider": "openai"}, 50) is None
 
     def test_image_tokens_capped(self):
         # A 24MP source downscaled to 3.75MP would be 5000 tokens raw; capped at 4784


### PR DESCRIPTION
Hey @dgahagan, I hope you're interested in accepting contributions. I have a homelab that I've been building out, and Shelf is the perfect solution for what I'm looking for. I run litellm+vllm with Gemma 4, though, and that exposes an OpenAI-compatible API rather than Anthropic or Ollama.

I leaned on @claude for this, but I tried to keep the PR in line with the conventions of the adjacent code. Please let me know if you have concerns.

# Details

Adds a third `vision_provider` — "openai" — alongside the existing anthropic and ollama backends. It targets any endpoint speaking the OpenAI Chat Completions API (OpenAI, Azure OpenAI, OpenRouter, or a local server such as vLLM / LM Studio / LocalAI) via a configurable base URL, so one branch covers the whole family.

- services/vision.py: `_detect_openai` (httpx, no SDK) with base64 data-URI images and json_object structured output; dispatch mirrors the Anthropic path (multi-image request up to MAX_TILES_PER_REQUEST, per-tile fallback beyond it). Extracts the shared JSON_ONLY_SUFFIX.
- config.py / tiling.py: OpenAI ingest cap (operator-tunable long edge, default 2048) so high-res tiling kicks in; cost estimate stays None since pricing varies across compatible endpoints.
- routers/settings.py + templates: base URL, API key, model, and image size fields; provider allowlist and independent key-clear handling.
- crypto.py: openai_api_key added to SENSITIVE_KEYS (encrypted at rest).
- Tests for provider dispatch, tiling, custom base URL, auth errors, and sensitive-key masking; README / CHANGELOG / Docker Hub docs updated.