### PR TITLE
Fix Add User: nested x-model can't write under Alpine CSP, plus surface server errors

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1254,13 +1254,13 @@
         <div class="border-t border-shelf-border pt-4">
             <h3 class="text-sm font-semibold text-shelf-muted mb-3">Add User</h3>
             <div class="grid grid-cols-2 gap-3">
-                <input x-model="newUser.username" type="text" placeholder="Username" required
+                <input x-model="newUsername" type="text" placeholder="Username" required
                     class="bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-sm text-shelf-text placeholder-shelf-muted/40 focus:outline-none focus:border-shelf-accent">
-                <input x-model="newUser.display_name" type="text" placeholder="Display Name (optional)"
+                <input x-model="newDisplayName" type="text" placeholder="Display Name (optional)"
                     class="bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-sm text-shelf-text placeholder-shelf-muted/40 focus:outline-none focus:border-shelf-accent">
-                <input x-model="newUser.password" type="password" placeholder="Password (min 8 chars)" required
+                <input x-model="newPassword" type="password" placeholder="Password (min 8 chars)" required
                     class="bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-sm text-shelf-text placeholder-shelf-muted/40 focus:outline-none focus:border-shelf-accent">
-                <select x-model="newUser.role"
+                <select x-model="newRole"
                     class="bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-sm text-shelf-text focus:outline-none focus:border-shelf-accent">
                     <option value="viewer">Viewer</option>
                     <option value="editor">Editor</option>

--- a/static/js/components-settings.js
+++ b/static/js/components-settings.js
@@ -9,6 +9,24 @@
 // Jinja-templated initial state is passed via data-* attributes on the
 // component root and read in init() from this.$el.dataset.
 
+// Fetch + parse JSON, but never throw: server responses to CSRF/auth
+// rejections (and unhandled 500s) are plain text/HTML, not JSON. Always
+// resolves to an {ok, message} shape so callers can surface real errors
+// instead of silently swallowing an uncaught exception.
+async function postJSON(url, opts) {
+    let r;
+    try {
+        r = await fetch(url, opts);
+    } catch {
+        return { ok: false, message: 'Network error — check your connection' };
+    }
+    try {
+        return await r.json();
+    } catch {
+        return { ok: false, message: r.ok ? 'Unexpected response from server' : `Request failed (${r.status})` };
+    }
+}
+
 document.addEventListener('alpine:init', function () {
 
     // settings.html — tab bar (persists active tab in localStorage)
@@ -387,32 +405,39 @@ document.addEventListener('alpine:init', function () {
     Alpine.data('usersPanel', function () {
         return {
             users: [],
-            newUser: { username: '', display_name: '', password: '', role: 'viewer' },
+            // Flat (not nested) properties: the Alpine CSP build cannot evaluate
+            // the assignment x-model needs for a nested path like "newUser.username".
+            newUsername: '',
+            newDisplayName: '',
+            newPassword: '',
+            newRole: 'viewer',
             addResult: false,
             async loadUsers() {
-                const r = await fetch('/api/users');
-                this.users = await r.json();
+                const d = await postJSON('/api/users', {});
+                if (Array.isArray(d)) this.users = d;
+                else console.error('Failed to load users:', d.message);
             },
             async addUser() {
                 this.addResult = false;
                 const form = new FormData();
-                form.append('username', this.newUser.username);
-                form.append('display_name', this.newUser.display_name);
-                form.append('password', this.newUser.password);
-                form.append('role', this.newUser.role);
-                const r = await fetch('/api/users', { method: 'POST', headers: { 'X-CSRF-Token': window.csrfToken() }, body: form });
-                const d = await r.json();
+                form.append('username', this.newUsername);
+                form.append('display_name', this.newDisplayName);
+                form.append('password', this.newPassword);
+                form.append('role', this.newRole);
+                const d = await postJSON('/api/users', { method: 'POST', headers: { 'X-CSRF-Token': window.csrfToken() }, body: form });
                 this.addResult = d;
                 if (d.ok) {
-                    this.newUser = { username: '', display_name: '', password: '', role: 'viewer' };
+                    this.newUsername = '';
+                    this.newDisplayName = '';
+                    this.newPassword = '';
+                    this.newRole = 'viewer';
                     await this.loadUsers();
                 }
             },
             async updateRole(id, role) {
                 const form = new FormData();
                 form.append('role', role);
-                const r = await fetch('/api/users/' + id + '/role', { method: 'POST', headers: { 'X-CSRF-Token': window.csrfToken() }, body: form });
-                const d = await r.json();
+                const d = await postJSON('/api/users/' + id + '/role', { method: 'POST', headers: { 'X-CSRF-Token': window.csrfToken() }, body: form });
                 if (!d.ok) alert(d.message);
                 else await this.loadUsers();
             },
@@ -421,14 +446,12 @@ document.addEventListener('alpine:init', function () {
                 if (!pw) return;
                 const form = new FormData();
                 form.append('password', pw);
-                const r = await fetch('/api/users/' + id + '/password', { method: 'POST', headers: { 'X-CSRF-Token': window.csrfToken() }, body: form });
-                const d = await r.json();
+                const d = await postJSON('/api/users/' + id + '/password', { method: 'POST', headers: { 'X-CSRF-Token': window.csrfToken() }, body: form });
                 alert(d.message);
             },
             async deleteUser(id, name) {
                 if (!confirm('Delete user ' + name + '?')) return;
-                const r = await fetch('/api/users/' + id, { method: 'DELETE', headers: { 'X-CSRF-Token': window.csrfToken() } });
-                const d = await r.json();
+                const d = await postJSON('/api/users/' + id, { method: 'DELETE', headers: { 'X-CSRF-Token': window.csrfToken() } });
                 if (!d.ok) alert(d.message);
                 else await this.loadUsers();
             }

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -10,6 +10,7 @@ import sqlite3
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from pathlib import Path
 
@@ -35,7 +36,38 @@ def _free_port() -> int:
 _SERVER_TIMEOUT = float(os.environ.get("E2E_SERVER_TIMEOUT", "30"))
 
 
-def _wait_for_server(url: str, timeout: float = _SERVER_TIMEOUT, proc: subprocess.Popen | None = None) -> None:
+class _OutputCapture:
+    """Drains a subprocess pipe on a background thread into a bounded buffer.
+
+    subprocess.PIPE has a small OS-level buffer (especially on Windows). If
+    nobody reads it, the child blocks the moment it fills — which stalls
+    uvicorn's own log writes and, since it's single-process, the whole server
+    with it. Reading continuously here keeps the pipe drained; the last N
+    lines are kept around for diagnostics if startup still fails.
+    """
+
+    def __init__(self, stream, max_lines: int = 200):
+        self._lines: list[str] = []
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(target=self._drain, args=(stream, max_lines), daemon=True)
+        self._thread.start()
+
+    def _drain(self, stream, max_lines: int) -> None:
+        try:
+            for raw_line in iter(stream.readline, b""):
+                with self._lock:
+                    self._lines.append(raw_line.decode(errors="replace").rstrip("\n"))
+                    if len(self._lines) > max_lines:
+                        del self._lines[0]
+        except Exception:
+            pass
+
+    def tail(self) -> str:
+        with self._lock:
+            return "\n".join(self._lines)
+
+
+def _wait_for_server(url: str, timeout: float = _SERVER_TIMEOUT, output: "_OutputCapture | None" = None) -> None:
     import json
     import urllib.request
     deadline = time.monotonic() + timeout
@@ -47,22 +79,9 @@ def _wait_for_server(url: str, timeout: float = _SERVER_TIMEOUT, proc: subproces
                 return
         except Exception:
             time.sleep(0.2)
-    # On failure, capture and display server stderr for diagnosis
-    stderr_output = ""
-    if proc and proc.stderr:
-        try:
-            proc.stderr.flush()
-            stderr_output = proc.stderr.read().decode(errors="replace") if isinstance(proc.stderr.read, type(b"".decode)) else ""
-        except Exception:
-            pass
-        if not stderr_output:
-            try:
-                stderr_output = proc.stderr.read(8192).decode(errors="replace") if proc.stderr.readable() else ""
-            except Exception:
-                stderr_output = "(could not read stderr)"
     raise RuntimeError(
         f"Server at {url} did not start within {timeout}s\n"
-        f"Server stderr:\n{stderr_output}"
+        f"Server output:\n{output.tail() if output else '(not captured)'}"
     )
 
 
@@ -98,12 +117,13 @@ def live_server():
         cwd=str(APP_DIR),
         env=env,
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
     )
+    output = _OutputCapture(proc.stdout)
 
     base_url = f"http://127.0.0.1:{port}"
     try:
-        _wait_for_server(f"{base_url}/health", proc=proc)
+        _wait_for_server(f"{base_url}/health", output=output)
         yield {"url": base_url, "data_dir": data_dir, "port": port}
     finally:
         proc.terminate()

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -20,3 +20,45 @@ def test_stats_page_loads(live_server, authed_page):
     assert authed_page.locator("body").is_visible()
     assert "error" not in authed_page.locator("body").inner_text().lower() or \
            authed_page.locator("body").inner_text() != ""
+
+
+def _open_users_tab(page, live_server):
+    page.goto(f"{live_server['url']}/settings")
+    page.get_by_role("button", name="Users").click()
+    page.wait_for_load_state("networkidle")
+
+
+def test_add_user_succeeds(live_server, authed_page):
+    """Filling in the Add User form creates the user and lists it."""
+    _open_users_tab(authed_page, live_server)
+
+    authed_page.fill('input[placeholder="Username"]', "e2enewuser")
+    authed_page.fill('input[placeholder="Password (min 8 chars)"]', "password123")
+    authed_page.get_by_role("button", name="Add User").click()
+
+    expect(authed_page.locator("span.text-shelf-success")).to_contain_text("created")
+    expect(authed_page.locator("text=@e2enewuser")).to_be_visible()
+
+
+def test_add_user_surfaces_server_rejection(live_server, authed_page):
+    """A non-JSON error response (CSRF/auth rejection) must show a visible
+    error instead of silently doing nothing.
+
+    Regression test for the bug where usersPanel.addUser() called
+    `await r.json()` unconditionally: a plain-text 403 from the CSRF/auth
+    layer made that throw, the exception went uncaught, and the Add User
+    button appeared to do nothing at all.
+    """
+    authed_page.route(
+        "**/api/users",
+        lambda route: route.fulfill(status=403, content_type="text/plain", body="CSRF validation failed")
+        if route.request.method == "POST" else route.continue_(),
+    )
+
+    _open_users_tab(authed_page, live_server)
+    authed_page.fill('input[placeholder="Username"]', "e2erejecteduser")
+    authed_page.fill('input[placeholder="Password (min 8 chars)"]', "password123")
+    authed_page.get_by_role("button", name="Add User").click()
+
+    expect(authed_page.locator("text=Request failed (403)")).to_be_visible()
+    expect(authed_page.locator("text=@e2erejecteduser")).not_to_be_visible()


### PR DESCRIPTION
## Summary

Fixes #2.

- **Primary bug**: the Add User form's inputs used `x-model="newUser.username"` (and `.display_name`/`.password`/`.role`) — a nested object property. The Alpine CSP build this app uses (`@alpinejs/csp`) can't evaluate the assignment `x-model` needs for a nested path, so typed values never reached the component's JS state. Every submission silently sent empty fields, no matter what was typed. Fixed by flattening `usersPanel`'s state to top-level properties (`newUsername`, `newDisplayName`, `newPassword`, `newRole`), the same CSP-safe pattern already used elsewhere in the file (`displayName`, `absUrl`, `hcToken`, etc). See the [issue](https://github.com/dgahagan/shelf/issues/2) for the full repro.
- **Secondary bug**: `usersPanel`'s fetch handlers (`loadUsers`/`addUser`/`updateRole`/`resetPassword`/`deleteUser`) called `r.json()` unconditionally. CSRF/auth rejections return plain-text bodies, so `r.json()` throws, the rejection goes uncaught, and the user gets zero feedback. Added a `postJSON` helper that always resolves to `{ok, message}` instead of throwing.
- **Test infra fix**: `tests/e2e/conftest.py`'s `live_server` fixture spawned uvicorn with unread `stdout`/`stderr` PIPEs. Once uvicorn's own log output filled the OS pipe buffer, the child blocked on its next write and the whole server stalled before ever answering `/health` — this hung every e2e run I tried locally until fixed. Now both streams are merged and drained continuously on a background thread instead of only being read (blockingly, without a size bound) in the timeout failure path.
- Added e2e coverage for the Users tab, which had none before: a happy-path Add User test, and a regression test that forces a non-JSON server rejection and asserts the error becomes visible instead of the button silently doing nothing.

## Not in scope (flagged for follow-up)

The same nested-`x-model` anti-pattern exists elsewhere and likely has the identical silent-failure bug, but is out of scope here: `intake.html`'s `book.title`/`book.authors`/`book.include` (inside an `x-for` loop), and `settings.html`'s `lib.included` and `hcStatuses[1..5]` (bracket-indexed). Worth a separate look.

## Test plan

- [x] `make check-csrf` / `python scripts/check_csrf_fetch.py` — passes
- [x] `make check-alpine` / `python scripts/check_alpine_csp.py` — passes
- [x] `python -m pytest tests/ --ignore=tests/e2e` — 478/478 passing (verified locally on Linux/WSL)
- [x] `python -m pytest tests/e2e/ -m e2e` — 36/36 passing, including the two new tests
- [x] Manually verified via a scripted Playwright repro that, pre-fix, `Alpine.$data(el).newUser` stayed empty after filling the form (console showed `Property assignments are prohibited in the CSP build`), and post-fix the user is actually created and appears in the list
- [x] Manually re-verified by running the app locally (uvicorn) and exercising Settings → Users → Add User by hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Originally opened against my fork at local-ha/shelf#2.
