### PR TITLE
Fix permanent crash-loop when a migration's ALTER outruns its schema_version row

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -284,7 +284,19 @@ def _run_migrations(db: sqlite3.Connection) -> list[str]:
         for version, description, sql in MIGRATIONS:
             if version in applied:
                 continue
-            db.execute(sql)
+            try:
+                db.execute(sql)
+            except sqlite3.OperationalError as e:
+                if "duplicate column name" not in str(e):
+                    raise
+                # ALTER TABLE is DDL: sqlite3 commits it immediately,
+                # independent of this connection's pending transaction. A
+                # prior run that applied this ALTER but was interrupted
+                # before the INSERT below committed (see the busy-timeout
+                # note above) leaves the column present with no
+                # schema_version row — replaying the ALTER then fails
+                # forever unless treated the same as an already-applied
+                # migration, exactly as _backfill_versions already does.
             db.execute(
                 "INSERT INTO schema_version (version, description) VALUES (?, ?)",
                 (version, description),

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -427,6 +427,50 @@ class TestManualValueMigration:
         assert "manual_value" in cols_after
         applied = {r["version"] for r in conn.execute("SELECT version FROM schema_version").fetchall()}
         assert 15 in applied
+
+    def test_migration_self_heals_column_present_without_version_row(self, tmp_path):
+        """Regression test: a real pre-0.5.0 -> 0.5.0+ upgrade can be
+        interrupted between migration 15's ALTER (which sqlite3 commits
+        immediately as DDL, independent of the pending transaction) and the
+        schema_version INSERT that records it — see G3's busy-timeout note
+        for how a real upgrade stalls mid-migration. That leaves
+        items.manual_value present but version 15 unrecorded, and every
+        subsequent startup replayed the same ALTER and crashed forever with
+        "duplicate column name: manual_value" instead of self-healing like
+        _backfill_versions already does for a first-run legacy DB.
+        """
+        db_path = tmp_path / "wedged.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        conn.executescript(SCHEMA)
+        for version, description, sql in MIGRATIONS:
+            if version >= 15:
+                continue
+            try:
+                conn.execute(sql)
+            except sqlite3.OperationalError:
+                pass
+            conn.execute(
+                "INSERT INTO schema_version (version, description) VALUES (?, ?)",
+                (version, description),
+            )
+        conn.executescript(MIGRATION_TABLES)
+        conn.commit()
+
+        # Simulate the interrupted upgrade: the ALTER landed, its
+        # schema_version row didn't.
+        conn.execute("ALTER TABLE items ADD COLUMN manual_value REAL DEFAULT NULL")
+        conn.commit()
+
+        # A crashing restart must not raise, and must still finish applying
+        # every later migration (16-21) that never got a chance to run.
+        _run_migrations(conn)
+        conn.commit()
+
+        applied = {r["version"] for r in conn.execute("SELECT version FROM schema_version").fetchall()}
+        assert applied == {v for v, _, _ in MIGRATIONS}
+        cols = {r["name"] for r in conn.execute("PRAGMA table_info(series_meta)").fetchall()}
+        assert {"complete", "hc_total", "hc_missing", "hc_checked_at"} <= cols
         conn.close()
 
 


### PR DESCRIPTION
Fixes #24.

## Problem

Upgrading a pre-0.5.0 database can leave the container permanently
crash-looping on startup with `sqlite3.OperationalError: duplicate column
name: manual_value` in `_run_migrations`. Confirmed on 0.5.0 through 0.8.0.

## Root cause

`ALTER TABLE` is DDL, and Python's `sqlite3` module commits it immediately,
independent of the connection's pending transaction:

```python
db.execute(sql)                                   # ALTER ... committed immediately
db.execute("INSERT INTO schema_version ...")       # not yet committed
```

If a real upgrade is interrupted between those two statements — the kind of
stall GOTCHAS.md's G3 already documents (five ~5s busy-timeout stalls
during a pre-0.5.0 migration) — the column lands but its `schema_version`
row never does. Every subsequent boot replays the same ALTER against a
column that already exists and crashes before ever reaching the INSERT that
would finally record it, so it never self-heals.

`_backfill_versions` already tolerates `sqlite3.OperationalError` for
exactly this reason, but only runs once against a completely empty
`schema_version` table. The incremental loop that every real upgrade takes
had no equivalent protection.

## Fix

Make the incremental loop in `_run_migrations` treat "duplicate column
name" the same way `_backfill_versions` already does: record the migration
as applied instead of crashing, and keep going. Verified this self-heals a
wedged `schema_version` row and correctly continues applying any later
migrations (16-21 in the reproduction) that never got a chance to run.

Any other `OperationalError` still propagates and fails startup loudly, as
before.

## Testing

- Added `test_migration_self_heals_column_present_without_version_row` to
  `tests/test_items.py`, alongside the existing `TestManualValueMigration`
  coverage — builds a DB in exactly the wedged state described above and
  asserts `_run_migrations` no longer raises and finishes applying every
  migration.
- `python -m pytest tests/ --ignore=tests/e2e` — 853 passed, 1 pre-existing
  unrelated failure (`test_keyfile_generated_with_restrictive_perms` —
  asserts POSIX `chmod 0o600` semantics, doesn't apply on this Windows dev
  machine).
- `python scripts/check_csrf_fetch.py` / `python scripts/check_alpine_csp.py`
  — both pass (unaffected by this change, ran for completeness).