### PR TITLE
Add optional credentialed Google Books support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,7 @@
 # Setting it here means the data directory alone is not enough to decrypt
 # stored credentials. Generate with: openssl rand -hex 32
 # SHELF_ENCRYPTION_KEY=
+
+# Optional Google Books API key. Anonymous Google Books lookups remain enabled
+# when this is unset. The key is sent only in the X-Goog-Api-Key header.
+# GOOGLE_BOOKS_API_KEY=

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Release](https://img.shields.io/github/v/release/dgahagan/shelf)](https://github.com/dgahagan/shelf/releases)
 [![Docker Pulls](https://img.shields.io/docker/pulls/dangahagan/shelf)](https://hub.docker.com/r/dangahagan/shelf)
 [![CI](https://github.com/dgahagan/shelf/actions/workflows/test.yml/badge.svg)](https://github.com/dgahagan/shelf/actions/workflows/test.yml)
-[![Unit tests](https://img.shields.io/badge/unit%20tests-1903%20passing-brightgreen)](https://github.com/dgahagan/shelf/actions/workflows/test.yml)
-[![E2E tests](https://img.shields.io/badge/e2e%20tests-183%20passing-brightgreen)](https://github.com/dgahagan/shelf/actions/workflows/test.yml)
+[![Unit tests](https://img.shields.io/badge/unit%20tests-1931%20passing-brightgreen)](https://github.com/dgahagan/shelf/actions/workflows/test.yml)
+[![E2E tests](https://img.shields.io/badge/e2e%20tests-184%20passing-brightgreen)](https://github.com/dgahagan/shelf/actions/workflows/test.yml)
 [![License: AGPL-3.0](https://img.shields.io/github/license/dgahagan/shelf)](LICENSE)
 
 A self-hosted home library catalog with barcode scanning, multi-mode scanning workflows, automatic metadata lookup, cover art, and collection management — all in a single Docker container.
@@ -259,7 +259,7 @@ Shelf queries free, public APIs to look up book and game information — no API 
 | Source | What it provides | API key required? |
 |--------|-----------------|-------------------|
 | [Open Library](https://openlibrary.org) | Title, author, description, cover art, publish info, title search | No |
-| [Google Books](https://books.google.com) | Fallback metadata and cover art | No |
+| [Google Books](https://books.google.com) | Fallback metadata and cover art | No (optional key supported) |
 | [Amazon Images](https://www.amazon.com) | Fallback cover art via ISBN | No |
 | [UPC Item DB](https://www.upcitemdb.com) | Title lookup from UPC barcodes (games, DVDs) | No |
 
@@ -272,6 +272,7 @@ Configure in Settings to unlock additional features:
 | Service | Enables | Link |
 |---------|---------|------|
 | **Hardcover** | Reading status sync, richer metadata, import/export, Discover page | [hardcover.app](https://hardcover.app) |
+| **Google Books** | Optional credentialed metadata, synopsis, and cover requests; anonymous access remains available | [Google Books API](https://developers.google.com/books) |
 | **IGDB** (Twitch) | Video game metadata, cover art, and platform info | [dev.twitch.tv/console](https://dev.twitch.tv/console) |
 | **ISBNdb** | Collection valuation with market prices | [isbndb.com](https://isbndb.com) |
 | **TMDb** | DVD/Blu-ray metadata and title search via UPC barcode | [themoviedb.org](https://www.themoviedb.org) |

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Release](https://img.shields.io/github/v/release/dgahagan/shelf)](https://github.com/dgahagan/shelf/releases)
 [![Docker Pulls](https://img.shields.io/docker/pulls/dangahagan/shelf)](https://hub.docker.com/r/dangahagan/shelf)
 [![CI](https://github.com/dgahagan/shelf/actions/workflows/test.yml/badge.svg)](https://github.com/dgahagan/shelf/actions/workflows/test.yml)
-[![Unit tests](https://img.shields.io/badge/unit%20tests-1931%20passing-brightgreen)](https://github.com/dgahagan/shelf/actions/workflows/test.yml)
-[![E2E tests](https://img.shields.io/badge/e2e%20tests-184%20passing-brightgreen)](https://github.com/dgahagan/shelf/actions/workflows/test.yml)
+[![Unit tests](https://img.shields.io/badge/unit%20tests-1903%20passing-brightgreen)](https://github.com/dgahagan/shelf/actions/workflows/test.yml)
+[![E2E tests](https://img.shields.io/badge/e2e%20tests-202%20passing-brightgreen)](https://github.com/dgahagan/shelf/actions/workflows/test.yml)
 [![License: AGPL-3.0](https://img.shields.io/github/license/dgahagan/shelf)](LICENSE)
 
 A self-hosted home library catalog with barcode scanning, multi-mode scanning workflows, automatic metadata lookup, cover art, and collection management — all in a single Docker container.

--- a/app/config.py
+++ b/app/config.py
@@ -161,6 +161,7 @@ SECRET_ENV_VARS = {
     "abs_url": "ABS_URL",
     "abs_token": "ABS_TOKEN",
     "hardcover_token": "HARDCOVER_TOKEN",
+    "google_books_api_key": "GOOGLE_BOOKS_API_KEY",
     "isbndb_api_key": "ISBNDB_API_KEY",
     "tmdb_api_key": "TMDB_API_KEY",
     "igdb_client_id": "IGDB_CLIENT_ID",

--- a/app/crypto.py
+++ b/app/crypto.py
@@ -40,6 +40,7 @@ SENSITIVE_KEYS: frozenset[str] = frozenset(
         "anthropic_api_key",
         "openai_api_key",
         "hardcover_token",
+        "google_books_api_key",
         "isbndb_api_key",
         "tmdb_api_key",
         "igdb_client_id",

--- a/app/routers/intake.py
+++ b/app/routers/intake.py
@@ -149,6 +149,7 @@ def _isbn_taken(isbn13: str, media_type: str) -> bool:
 async def _confirm_one(
     book: IntakeBook, client: httpx.AsyncClient, search_lang: str, preferred_marc: str,
     location_id: int | None, owned: bool, hc_token: str | None,
+    google_api_key: str | None,
 ) -> tuple[str, dict, int | None]:
     """Resolve one confirmed row to an ``added``/``skipped`` entry.
 
@@ -186,7 +187,9 @@ async def _confirm_one(
         try:
             # Trailing `_` = the rate-limited flag. Photo Intake's confirm step
             # has no scan card to render it on — deliberate, not an oversight.
-            metadata, _, hc_ids, _ = await items_common._lookup_metadata(printed_isbn13, hc_token, client)
+            metadata, _, hc_ids, _ = await items_common._lookup_metadata(
+                printed_isbn13, hc_token, client, google_api_key=google_api_key
+            )
         except Exception:
             logger.warning("Intake: metadata lookup failed for ISBN %s", printed_isbn13)
             metadata, hc_ids = None, {}
@@ -314,6 +317,7 @@ async def confirm_books(payload: IntakeConfirm):
         search_lang = get_setting(db, "metadata_search_lang") or "en"
         # get_setting, never get_all_settings — the latter drops env-only keys (G15).
         hc_token = get_setting(db, "hardcover_token") or None
+        google_api_key = get_setting(db, "google_books_api_key") or None
     preferred_marc = national.iso_to_marc(search_lang)
 
     async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
@@ -324,7 +328,7 @@ async def confirm_books(payload: IntakeConfirm):
 
             status, entry, item_id = await _confirm_one(
                 book, client, search_lang, preferred_marc, payload.location_id,
-                payload.owned, hc_token)
+                payload.owned, hc_token, google_api_key)
             if status == "added":
                 added.append(entry)
                 new_item_ids.append(item_id)

--- a/app/routers/items.py
+++ b/app/routers/items.py
@@ -366,15 +366,16 @@ async def scan_isbn(
             {"status": "duplicate", "isbn": isbn13, "title": existing["title"], "item_id": existing["id"]},
         )
 
-    # Get Hardcover token for metadata enrichment
+    # Get optional metadata-provider credentials.
     with get_db() as db:
         hc_token = get_setting(db, "hardcover_token") or None
+        google_api_key = get_setting(db, "google_books_api_key") or None
 
     logger.info("Scanning ISBN %s (type=%s, mode=%s)", isbn13, media_type, mode)
     try:
         async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
             metadata, source, hc_ids, lookup_rate_limited = await items_common._lookup_metadata(
-                isbn13, hc_token, client
+                isbn13, hc_token, client, google_api_key=google_api_key
             )
 
             if not metadata:
@@ -982,12 +983,14 @@ async def fetch_synopsis(item_id: int, _=Depends(require_role("editor"))):
             "SELECT isbn, title, authors FROM items WHERE id = ?", (item_id,)
         ).fetchone()
         hc_token = get_setting(db, "hardcover_token")
+        google_api_key = get_setting(db, "google_books_api_key")
     if not item:
         return {"ok": False, "message": "Item not found"}
 
     async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
         desc = await synopsis_svc.fetch_description(
-            item["isbn"], item["title"], item["authors"], client, hc_token=hc_token)
+            item["isbn"], item["title"], item["authors"], client,
+            hc_token=hc_token, google_api_key=google_api_key)
 
     if desc:
         with get_db() as db:
@@ -1011,6 +1014,7 @@ async def backfill_synopses_stream(request: Request, _=Depends(require_role("adm
             synopsis_svc.BOOK_MEDIA_TYPES,
         ).fetchall()
         hc_token = get_setting(db, "hardcover_token")
+        google_api_key = get_setting(db, "google_books_api_key")
 
     if not items:
         async def empty_stream():
@@ -1028,7 +1032,7 @@ async def backfill_synopses_stream(request: Request, _=Depends(require_role("adm
                     try:
                         desc = await synopsis_svc.fetch_description(
                             item["isbn"], item["title"], item["authors"], client,
-                            hc_token=hc_token)
+                            hc_token=hc_token, google_api_key=google_api_key)
                     except Exception:
                         logger.exception("Synopsis fetch failed for item %d", item["id"])
                     if desc:
@@ -1192,7 +1196,6 @@ async def test_igdb_key(request: Request, _=Depends(require_role("admin"))):
         return {"ok": False, "message": "Both Client ID and Client Secret are required"}
     async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
         return await igdb.test_credentials(client_id, client_secret, client)
-
 
 
 

--- a/app/routers/items_catalog.py
+++ b/app/routers/items_catalog.py
@@ -242,11 +242,14 @@ async def add_book_from_search(
 
     with get_db() as db:
         hc_token = get_setting(db, "hardcover_token") or None
+        google_api_key = get_setting(db, "google_books_api_key") or None
 
     async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
         # `_` = the rate-limited flag. *Add by ISBN* has no scan card to
         # render it on — deliberate, not an oversight.
-        metadata, source, hc_ids, _ = await items_common._lookup_metadata(isbn13, hc_token, client)
+        metadata, source, hc_ids, _ = await items_common._lookup_metadata(
+            isbn13, hc_token, client, google_api_key=google_api_key
+        )
 
         if not metadata:
             items_common._log_scan(isbn13, media_type, "not_found")

--- a/app/routers/items_common.py
+++ b/app/routers/items_common.py
@@ -132,7 +132,8 @@ def filter_counts(db, values: dict, total: int) -> dict:
 def _toast_header(message: str, toast_type: str = "success") -> str:
     return json.dumps({"showToast": {"message": message, "type": toast_type}})
 
-async def _lookup_metadata(isbn13: str, hc_token: str | None, client: httpx.AsyncClient) -> tuple[dict | None, str, dict, bool]:
+async def _lookup_metadata(isbn13: str, hc_token: str | None, client: httpx.AsyncClient,
+                           *, google_api_key: str | None = None) -> tuple[dict | None, str, dict, bool]:
     """Look up book metadata across sources.
 
     Returns `(metadata, source, hc_ids, rate_limited)`. `rate_limited` is true
@@ -185,7 +186,8 @@ async def _lookup_metadata(isbn13: str, hc_token: str | None, client: httpx.Asyn
             }
 
     if not metadata:
-        metadata = await googlebooks.lookup(isbn13, client, on_rate_limit=_saw_rate_limit)
+        metadata = await googlebooks.lookup(
+            isbn13, client, api_key=google_api_key, on_rate_limit=_saw_rate_limit)
         if metadata:
             source = "google"
 

--- a/app/routers/items_covers.py
+++ b/app/routers/items_covers.py
@@ -108,6 +108,17 @@ def _search_note(media_type: str | None, creds: dict) -> str | None:
     return _SEARCH_NOTES.get(covers.MEDIA_TYPE_PROVIDERS.get(media_type or ""))
 
 
+def _cover_search_credentials(db, media_type: str | None) -> dict[str, str]:
+    """Load required provider credentials plus the optional Google book key."""
+    keys = covers.required_credentials(media_type)
+    creds = {key: get_setting(db, key) for key in keys}
+    if not keys:
+        google_key = get_setting(db, "google_books_api_key")
+        if google_key:
+            creds["google_books_api_key"] = google_key
+    return creds
+
+
 @router.get("/items/{item_id}/cover-search")
 async def cover_search(request: Request, item_id: int, query: str | None = None, _=Depends(require_role("editor"))):
     """Search for cover candidates by title/author. Returns HTMX fragment."""
@@ -118,13 +129,10 @@ async def cover_search(request: Request, item_id: int, query: str | None = None,
             "FROM items WHERE id = ?", (item_id,)
         ).fetchone()
         # Key-by-key through get_setting, never the bulk settings accessor:
-        # all three provider keys are in SECRET_ENV_VARS, and the bulk one
+        # Provider credentials are in SECRET_ENV_VARS, and the bulk one
         # returns only keys that have a row, so an env-only install would be
         # told its provider is unconfigured (G15).
-        creds = {} if not item else {
-            key: get_setting(db, key)
-            for key in covers.required_credentials(item["media_type"])
-        }
+        creds = {} if not item else _cover_search_credentials(db, item["media_type"])
     if not item:
         return HTMLResponse("Not found", status_code=404)
 
@@ -173,10 +181,7 @@ async def cover_select(
         # Same key-by-key build as cover_search — this failure path re-renders
         # the grid, and a DVD whose pick failed must not fall back to book
         # results (G15 again, for the same env-only reason).
-        creds = {} if not item else {
-            key: get_setting(db, key)
-            for key in covers.required_credentials(item["media_type"])
-        }
+        creds = {} if not item else _cover_search_credentials(db, item["media_type"])
     if not item:
         return HTMLResponse("Not found", status_code=404)
 

--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -9,7 +9,7 @@ from app.auth import require_role
 from app.config import DATABASE_PATH, DATA_DIR
 from app.crypto import SENSITIVE_KEYS, encrypt_value, get_encryption_key
 from app.currency import CURRENCIES, invalidate_cache as invalidate_currency_cache
-from app.database import get_db
+from app.database import get_db, get_setting
 from app.nav import HIDEABLE_KEYS, invalidate_cache as invalidate_nav_cache
 from app.services.national import SEARCH_LANGS
 
@@ -21,6 +21,7 @@ _INTEGRATION_KEYS = (
     "isbndb_api_key",
     "tmdb_api_key",
     "hardcover_token",
+    "google_books_api_key",
     "igdb_client_id",
     "igdb_client_secret",
 )
@@ -62,6 +63,27 @@ async def update_settings(request: Request):
             _upsert_setting(db, key, value, cleared=form.get(f"clear_{key}") == "on")
     invalidate_nav_cache()  # hardcover_token gates the Discover tab
     return RedirectResponse(url="/settings", status_code=303)
+
+
+@router.post("/google-books/test")
+async def test_google_books(request: Request):
+    """Test a submitted or configured Google Books API key."""
+    from app.services import googlebooks
+
+    try:
+        body = await request.json()
+    except Exception:
+        return {"ok": False, "message": "Invalid request"}
+    if not isinstance(body, dict):
+        return {"ok": False, "message": "Invalid request"}
+
+    api_key = (body.get("api_key") or "").strip()
+    if not api_key:
+        with get_db() as db:
+            api_key = get_setting(db, "google_books_api_key")
+    if not api_key:
+        return {"ok": False, "message": "No API key configured"}
+    return await googlebooks.test_connection(api_key)
 
 
 @router.post("/vision")

--- a/app/routers/store.py
+++ b/app/routers/store.py
@@ -104,6 +104,7 @@ async def store_queue(request: Request, _=Depends(require_role("editor"))):
 
     with get_db() as db:
         hc_token = get_setting(db, "hardcover_token") or None
+        google_api_key = get_setting(db, "google_books_api_key") or None
 
     results = []
     async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
@@ -130,7 +131,9 @@ async def store_queue(request: Request, _=Depends(require_role("editor"))):
                 # `_` = the rate-limited flag. Store Mode's queue flush has no
                 # scan card to render it on; inventing a surface for it is a
                 # later plan's scope, not an oversight.
-                metadata, source, hc_ids, _ = await items_common._lookup_metadata(isbn13, hc_token, client)
+                metadata, source, hc_ids, _ = await items_common._lookup_metadata(
+                    isbn13, hc_token, client, google_api_key=google_api_key
+                )
             except Exception:
                 logger.warning("Store queue: metadata lookup failed for %s", isbn13)
 

--- a/app/services/covers.py
+++ b/app/services/covers.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 import httpx
 
 from app.config import COVERS_DIR
-from app.services import igdb, outbound, tmdb
+from app.services import googlebooks, igdb, outbound, tmdb
 
 logger = logging.getLogger(__name__)
 
@@ -105,33 +105,21 @@ def save_uploaded_cover(item_id: int, content: bytes) -> str | None:
     return f"covers/{item_id}.jpg"
 
 
-async def search_cover_by_title(title: str, author: str | None, client: httpx.AsyncClient) -> list[dict]:
+async def search_cover_by_title(
+    title: str,
+    author: str | None,
+    client: httpx.AsyncClient,
+    *,
+    google_api_key: str | None = None,
+) -> list[dict]:
     """Search for cover candidates by title/author. Returns list of {url, source, thumbnail}."""
     candidates = []
 
     # Google Books search
     try:
-        q = title
-        if author:
-            q += f"+inauthor:{author.split(',')[0].split('&')[0].strip()}"
-        resp = await outbound.fetch(
-            client, "GET",
-            "https://www.googleapis.com/books/v1/volumes",
-            params={"q": q, "maxResults": "5"},
-            timeout=10,
-        )
-        if resp.status_code == 200:
-            data = resp.json()
-            for item in data.get("items", []):
-                images = item.get("volumeInfo", {}).get("imageLinks", {})
-                thumb = images.get("thumbnail") or images.get("smallThumbnail")
-                large = images.get("large") or images.get("medium") or thumb
-                if thumb:
-                    candidates.append({
-                        "url": large.replace("http://", "https://"),
-                        "thumbnail": thumb.replace("http://", "https://"),
-                        "source": "Google Books",
-                    })
+        candidates.extend(await googlebooks.search_covers(
+            title, author, client, api_key=google_api_key
+        ))
     except Exception:
         pass
 
@@ -250,7 +238,12 @@ async def search_covers(item, query: str, client: httpx.AsyncClient, *, creds: d
     # Called as the bare module global on purpose: eight tests in
     # tests/test_covers.py patch `covers.search_cover_by_title` by attribute,
     # and a local alias or a from-import would detach every one of them.
-    return await search_cover_by_title(query, _col(item, "authors"), client)
+    return await search_cover_by_title(
+        query,
+        _col(item, "authors"),
+        client,
+        google_api_key=creds.get("google_books_api_key"),
+    )
 
 
 async def _tmdb_candidates(item, query: str, client: httpx.AsyncClient, creds: dict) -> list[dict]:

--- a/app/services/googlebooks.py
+++ b/app/services/googlebooks.py
@@ -3,14 +3,23 @@ from collections.abc import Callable
 
 import httpx
 
+from app.config import HTTP_TIMEOUT
 from app.services import outbound
 
 logger = logging.getLogger(__name__)
+VOLUMES_URL = "https://www.googleapis.com/books/v1/volumes"
+
+
+def _api_headers(api_key: str | None) -> dict[str, str]:
+    """Return credential headers without ever putting the key in a URL."""
+    key = (api_key or "").strip()
+    return {"X-Goog-Api-Key": key} if key else {}
 
 
 async def lookup(
     isbn: str, client: httpx.AsyncClient,
-    *, on_rate_limit: Callable[[], None] | None = None,
+    *, api_key: str | None = None,
+    on_rate_limit: Callable[[], None] | None = None,
 ) -> dict | None:
     """Look up a book by ISBN via Google Books API. Returns metadata dict or None.
 
@@ -25,8 +34,9 @@ async def lookup(
     try:
         resp = await outbound.fetch(
             client, "GET",
-            "https://www.googleapis.com/books/v1/volumes",
+            VOLUMES_URL,
             params={"q": f"isbn:{isbn}"},
+            headers=_api_headers(api_key),
         )
     except Exception:
         logger.debug("Google Books lookup failed for ISBN %s", isbn, exc_info=True)
@@ -106,16 +116,23 @@ async def lookup(
         return None
 
 
-async def search_by_title_author(title: str, author: str | None, client: httpx.AsyncClient,
-                                 limit: int = 5) -> list[dict]:
+async def search_by_title_author(
+    title: str,
+    author: str | None,
+    client: httpx.AsyncClient,
+    limit: int = 5,
+    *,
+    api_key: str | None = None,
+) -> list[dict]:
     """Field-scoped volume search. Returns summaries including description."""
     query = f'intitle:"{title}"'
     if author:
         query += f' inauthor:"{author}"'
     resp = await outbound.fetch(
         client, "GET",
-        "https://www.googleapis.com/books/v1/volumes",
+        VOLUMES_URL,
         params={"q": query, "maxResults": str(limit)},
+        headers=_api_headers(api_key),
     )
     if resp.status_code != 200:
         logger.debug("Google Books search failed for %r: HTTP %d", query, resp.status_code)
@@ -132,3 +149,66 @@ async def search_by_title_author(title: str, author: str | None, client: httpx.A
             "description": info.get("description"),
         })
     return results
+
+
+async def search_covers(
+    title: str,
+    author: str | None,
+    client: httpx.AsyncClient,
+    limit: int = 5,
+    *,
+    api_key: str | None = None,
+) -> list[dict]:
+    """Search Google Books for cover candidates."""
+    query = title
+    if author:
+        query += f"+inauthor:{author.split(',')[0].split('&')[0].strip()}"
+    resp = await outbound.fetch(
+        client,
+        "GET",
+        VOLUMES_URL,
+        params={"q": query, "maxResults": str(limit)},
+        headers=_api_headers(api_key),
+        timeout=10,
+    )
+    if resp.status_code != 200:
+        logger.debug("Google Books cover search failed for %r: HTTP %d", query, resp.status_code)
+        return []
+
+    results = []
+    for item in resp.json().get("items", []):
+        images = item.get("volumeInfo", {}).get("imageLinks", {})
+        thumb = images.get("thumbnail") or images.get("smallThumbnail")
+        large = images.get("large") or images.get("medium") or thumb
+        if thumb:
+            results.append({
+                "url": large.replace("http://", "https://"),
+                "thumbnail": thumb.replace("http://", "https://"),
+                "source": "Google Books",
+            })
+    return results
+
+
+async def test_connection(api_key: str) -> dict:
+    """Validate a key without returning provider response bodies or secrets."""
+    if not _api_headers(api_key):
+        return {"ok": False, "message": "No API key configured"}
+    try:
+        async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+            resp = await outbound.fetch(
+                client,
+                "GET",
+                VOLUMES_URL,
+                params={"q": "isbn:9780140328721", "maxResults": "1"},
+                headers=_api_headers(api_key),
+            )
+    except Exception:
+        return {"ok": False, "message": "Connection failed — check network"}
+
+    if resp.status_code == 200:
+        return {"ok": True, "message": "Connected to Google Books"}
+    if resp.status_code in (401, 403):
+        return {"ok": False, "message": "Google Books rejected the API key"}
+    if resp.status_code == 429:
+        return {"ok": False, "message": "Google Books quota exceeded"}
+    return {"ok": False, "message": f"Google Books returned HTTP {resp.status_code}"}

--- a/app/services/synopsis.py
+++ b/app/services/synopsis.py
@@ -53,7 +53,8 @@ def _result_ok(authors: str | None, query_title: str, res: dict) -> bool:
 
 
 async def fetch_description(isbn: str | None, title: str | None, authors: str | None,
-                            client: httpx.AsyncClient, hc_token: str | None = None) -> str | None:
+                            client: httpx.AsyncClient, hc_token: str | None = None,
+                            google_api_key: str | None = None) -> str | None:
     """Find a description via Google Books (ISBN), then Hardcover (when a
     token is configured), then Open Library work search, then Google Books
     title/author search. Returns None if nothing credible is found.
@@ -62,7 +63,7 @@ async def fetch_description(isbn: str | None, title: str | None, authors: str | 
     is per-IP and exhausts under bulk backfills, and Open Library work
     records are frequently description-less even when the search matches."""
     if isbn:
-        meta = await googlebooks.lookup(isbn, client)
+        meta = await googlebooks.lookup(isbn, client, api_key=google_api_key)
         if meta and meta.get("description"):
             return meta["description"]
 
@@ -95,7 +96,9 @@ async def fetch_description(isbn: str | None, title: str | None, authors: str | 
         logger.debug("Open Library synopsis search failed for %r", title)
 
     try:
-        results = await googlebooks.search_by_title_author(search_title, first_author, client)
+        results = await googlebooks.search_by_title_author(
+            search_title, first_author, client, api_key=google_api_key
+        )
         for res in results:
             if _result_ok(authors, search_title, res) and res.get("description"):
                 return res["description"]

--- a/app/templates/fragments/settings/integrations.html
+++ b/app/templates/fragments/settings/integrations.html
@@ -551,6 +551,60 @@
         </div>
     </div>
 
+    <!-- Google Books -->
+    <div class="bg-shelf-card rounded-xl border border-shelf-border p-6"
+         x-data="googleBooksPanel"
+         data-google-books-saved="{{ '1' if secrets_present['google_books_api_key'] else '' }}">
+        <h2 class="text-lg font-semibold mb-1">Google Books</h2>
+        <p class="text-sm text-shelf-muted mb-4">
+            Optional. Google Books continues to work anonymously without a key.
+            When configured, the key is used only for Google Books API requests.
+        </p>
+        <form action="/api/settings" method="post" class="space-y-3">
+            <div>
+                <label for="google_books_api_key" class="block text-sm font-medium text-shelf-muted mb-1">API Key</label>
+                <div class="flex gap-2">
+                    <input type="password" id="google_books_api_key" name="google_books_api_key"
+                           x-model="googleBooksKey" autocomplete="new-password"
+                           placeholder="{% if secrets_saved['google_books_api_key'] %}Saved — leave blank to keep{% else %}Optional Google Books API key{% endif %}"
+                           class="flex-1 min-w-0 bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-shelf-text focus:ring-2 focus:ring-shelf-accent outline-none">
+                    <button type="button"
+                            @click="testGoogleBooks"
+                            :disabled="googleBooksTesting || (!googleBooksKey && !googleBooksSaved)"
+                            class="px-3 py-2 bg-shelf-hover text-shelf-text rounded-lg text-sm hover:bg-shelf-border transition-colors disabled:opacity-50 whitespace-nowrap shrink-0">
+                        <span x-show="!googleBooksTesting">Test Key</span>
+                        <span x-show="googleBooksTesting">Testing...</span>
+                    </button>
+                </div>
+                <p class="text-xs text-shelf-muted mt-1">
+                    Stored encrypted and sent only in the <span class="font-mono">X-Goog-Api-Key</span> request header.
+                </p>
+                <div class="mt-1.5 h-5">
+                    <template x-if="googleBooksStatus && googleBooksStatus.ok">
+                        <p class="text-xs text-shelf-success flex items-center gap-1">
+                            <span class="inline-block w-2 h-2 rounded-full bg-shelf-success"></span>
+                            <span x-text="googleBooksStatus.message"></span>
+                        </p>
+                    </template>
+                    <template x-if="googleBooksStatus && !googleBooksStatus.ok">
+                        <p class="text-xs text-shelf-error flex items-center gap-1">
+                            <span class="inline-block w-2 h-2 rounded-full bg-shelf-error"></span>
+                            <span x-text="googleBooksStatus.message"></span>
+                        </p>
+                    </template>
+                </div>
+            </div>
+            {% if secrets_saved['google_books_api_key'] %}
+            <label class="flex items-center gap-2 text-xs text-shelf-muted">
+                <input type="checkbox" name="clear_google_books_api_key" class="rounded border-shelf-border"> Remove saved key
+            </label>
+            {% endif %}
+            <button type="submit" class="px-4 py-2 bg-shelf-accent text-white rounded-lg text-sm hover:bg-shelf-accent2 transition-colors">
+                Save
+            </button>
+        </form>
+    </div>
+
     <!-- Movie Database (TMDb) -->
     <div class="bg-shelf-card rounded-xl border border-shelf-border p-6"
          x-data="tmdbPanel"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,7 @@ priority** over anything stored:
 | Variable | Setting |
 |---|---|
 | `HARDCOVER_TOKEN` | Hardcover API token |
+| `GOOGLE_BOOKS_API_KEY` | Optional Google Books API key; anonymous lookups remain available when unset |
 | `ABS_URL`, `ABS_TOKEN` | Audiobookshelf server URL and API token |
 | `ISBNDB_API_KEY` | ISBNdb key (valuation) |
 | `TMDB_API_KEY` | TMDb credential (DVD / Blu-ray metadata **and** DVD cover search) — either the 32-character v3 API Key or the v4 Read Access Token |

--- a/docs/user-guide/integrations.md
+++ b/docs/user-guide/integrations.md
@@ -71,6 +71,13 @@ now probes TMDb exactly the way a real lookup does.
 numbers, value-over-time stats. See
 [Stats & valuation](stats-and-valuation.md).
 
+## Google Books (optional API key)
+
+Google Books remains available anonymously. An optional API key can be saved
+in Settings to authenticate ISBN, synopsis, and cover searches. Shelf sends it
+only in the `X-Goog-Api-Key` request header; it is stored encrypted and never
+placed in request URLs.
+
 ## Vision providers (Photo Intake)
 
 Anthropic, any OpenAI-compatible endpoint, or Ollama. See
@@ -84,10 +91,11 @@ same idea: an ntfy topic or JSON webhook URL for the overdue-loan digest. See
 
 ## Always-on sources (no key)
 
-Open Library, Google Books (keyless), Amazon cover images, UPC Item DB, and
-the Deutsche Nationalbibliothek for German ISBNs. Lookups send only the ISBN
-or UPC — never your account, collection or personal data. Requests to every
-provider are paced to its published rate limit. UPC Item DB's free tier is
+Open Library, Google Books (anonymous by default), Amazon cover images, UPC Item DB, and
+the Deutsche Nationalbibliothek for German ISBNs. Apart from credentials you
+explicitly configure, lookups send only the ISBN or UPC — never your account,
+collection or personal data. Requests to every provider are paced to its
+published rate limit. UPC Item DB's free tier is
 the tightest of them at six lookups a minute, so Shelf leaves ten seconds
 between consecutive barcode lookups: scanning a stack of discs or games is
 deliberately unhurried. One scan on its own never waits, and ISBNs are not
@@ -105,7 +113,7 @@ can be starved at once. See
 ## Supplying keys by environment instead
 
 Every key except the vision providers can come from an environment variable
-(`HARDCOVER_TOKEN`, `ABS_URL`/`ABS_TOKEN`, `ISBNDB_API_KEY`, `TMDB_API_KEY`,
+(`HARDCOVER_TOKEN`, `GOOGLE_BOOKS_API_KEY`, `ABS_URL`/`ABS_TOKEN`, `ISBNDB_API_KEY`, `TMDB_API_KEY`,
 `IGDB_CLIENT_ID`/`IGDB_CLIENT_SECRET`), which overrides whatever is stored. The
 secret field stays blank in Settings — Shelf never echoes a secret back — but
 **Test key** still works against it, so you can confirm the key without pasting

--- a/static/js/components-settings.js
+++ b/static/js/components-settings.js
@@ -298,6 +298,28 @@ document.addEventListener('alpine:init', function () {
         };
     });
 
+    // settings.html — Google Books card (optional credential)
+    Alpine.data('googleBooksPanel', function () {
+        return {
+            googleBooksStatus: false, googleBooksTesting: false,
+            googleBooksKey: '', googleBooksSaved: false,
+            init() {
+                this.googleBooksSaved = this.$el.dataset.googleBooksSaved === '1';
+            },
+            testGoogleBooks() {
+                if (!this.googleBooksKey && !this.googleBooksSaved) return;
+                this.googleBooksTesting = true; this.googleBooksStatus = false;
+                fetch('/api/settings/google-books/test', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.csrfToken() },
+                    body: JSON.stringify({ api_key: this.googleBooksKey })
+                }).then(r => r.json())
+                  .then(d => { this.googleBooksStatus = d; this.googleBooksTesting = false; })
+                  .catch(() => { this.googleBooksStatus = { ok: false, message: 'Connection failed' }; this.googleBooksTesting = false; });
+            }
+        };
+    });
+
     // settings.html — TMDb card (test key button)
     Alpine.data('tmdbPanel', function () {
         return {

--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -16,6 +16,30 @@ def test_settings_page_loads(live_server, authed_page):
     expect(authed_page.locator("body")).to_contain_text("Settings")
 
 
+def test_google_books_optional_key_card_and_test_action(live_server, authed_page):
+    """The write-only card is CSP-functional without calling Google."""
+    authed_page.route(
+        "**/api/settings/google-books/test",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"ok": true, "message": "Connected to Google Books"}',
+        ),
+    )
+    authed_page.goto(f"{live_server['url']}/settings")
+    authed_page.get_by_role("button", name="Integrations").click()
+
+    card = authed_page.locator("[data-google-books-saved]")
+    expect(card).to_contain_text("Optional")
+    key_input = card.locator('input[name="google_books_api_key"]')
+    expect(key_input).to_be_visible()
+    expect(key_input).to_have_value("")
+
+    key_input.fill("fake-e2e-google-key")
+    card.get_by_role("button", name="Test Key").click()
+    expect(card).to_contain_text("Connected to Google Books")
+
+
 def test_stats_page_loads(live_server, authed_page):
     """Stats page renders without error."""
     authed_page.goto(f"{live_server['url']}/stats")

--- a/tests/test_cover_dispatch.py
+++ b/tests/test_cover_dispatch.py
@@ -106,6 +106,19 @@ class TestTheBookPathIsUnchanged:
         assert tmdb.mock_calls == []
         assert igdb.mock_calls == []
 
+    async def test_optional_google_key_reaches_book_cover_search(
+        self, book_search, no_providers
+    ):
+        tmdb, igdb = no_providers
+        await covers.search_covers(
+            _item(media_type="book"), "Dune", object(),
+            creds={"google_books_api_key": "google-key"},
+        )
+
+        assert book_search.await_args.kwargs["google_api_key"] == "google-key"
+        assert tmdb.mock_calls == []
+        assert igdb.mock_calls == []
+
     @pytest.mark.parametrize("media_type", ["vinyl_lp", None, ""])
     async def test_an_unknown_media_type_takes_the_book_branch(
         self, media_type, book_search, no_providers

--- a/tests/test_covers.py
+++ b/tests/test_covers.py
@@ -570,6 +570,23 @@ class TestTheRouteKnowsWhatTheItemIs:
 
         assert search.await_args.kwargs["creds"] == {}
 
+    def test_book_cover_search_receives_env_google_key(
+        self, editor_client, db, monkeypatch
+    ):
+        from app.services import covers
+
+        item_id = _insert_item(db, title="Dune", isbn="9780900007007")
+        db.commit()
+        monkeypatch.setenv("GOOGLE_BOOKS_API_KEY", "env-google-key")
+        search = AsyncMock(return_value=[])
+        monkeypatch.setattr(covers, "search_covers", search)
+
+        editor_client.get(f"/api/items/{item_id}/cover-search")
+
+        assert search.await_args.kwargs["creds"] == {
+            "google_books_api_key": "env-google-key"
+        }
+
 
 class TestTheUnconfiguredProviderNote:
     """T4 — "not configured" is not "not found". The note is `None` unless a

--- a/tests/test_googlebooks_credentials.py
+++ b/tests/test_googlebooks_credentials.py
@@ -1,0 +1,113 @@
+"""Optional credential coverage for every Google Books request variant."""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from app.services import googlebooks
+
+
+def _volume_payload():
+    return {"items": [{"volumeInfo": {
+        "title": "Dune",
+        "authors": ["Frank Herbert"],
+        "description": "A desert planet epic.",
+        "imageLinks": {
+            "thumbnail": "http://books.google.com/thumb.jpg",
+            "large": "http://books.google.com/large.jpg",
+        },
+    }}]}
+
+
+@pytest.mark.asyncio
+async def test_all_request_variants_send_key_in_header_only():
+    sentinel = "sentinel-google-key"
+    fake_fetch = AsyncMock(return_value=httpx.Response(200, json=_volume_payload()))
+
+    with patch("app.services.googlebooks.outbound.fetch", new=fake_fetch):
+        await googlebooks.lookup("9780441172719", object(), api_key=sentinel)
+        await googlebooks.search_by_title_author(
+            "Dune", "Frank Herbert", object(), api_key=sentinel
+        )
+        await googlebooks.search_covers(
+            "Dune", "Frank Herbert", object(), api_key=sentinel
+        )
+
+    assert fake_fetch.await_count == 3
+    for request_call in fake_fetch.await_args_list:
+        assert request_call.kwargs["headers"] == {"X-Goog-Api-Key": sentinel}
+        assert sentinel not in request_call.args[2]
+        assert sentinel not in repr(request_call.kwargs["params"])
+        assert "key" not in request_call.kwargs["params"]
+
+
+@pytest.mark.asyncio
+async def test_all_request_variants_remain_anonymous_without_key():
+    fake_fetch = AsyncMock(return_value=httpx.Response(200, json=_volume_payload()))
+
+    with patch("app.services.googlebooks.outbound.fetch", new=fake_fetch):
+        await googlebooks.lookup("9780441172719", object())
+        await googlebooks.search_by_title_author("Dune", None, object())
+        await googlebooks.search_covers("Dune", None, object())
+
+    assert fake_fetch.await_count == 3
+    assert all(call.kwargs["headers"] == {} for call in fake_fetch.await_args_list)
+
+
+@pytest.mark.parametrize("status,expected", [
+    (200, {"ok": True, "message": "Connected to Google Books"}),
+    (401, {"ok": False, "message": "Google Books rejected the API key"}),
+    (403, {"ok": False, "message": "Google Books rejected the API key"}),
+    (429, {"ok": False, "message": "Google Books quota exceeded"}),
+    (503, {"ok": False, "message": "Google Books returned HTTP 503"}),
+])
+@pytest.mark.asyncio
+async def test_connection_results_are_sanitized(status, expected):
+    sentinel = "sentinel-test-key"
+    fake_fetch = AsyncMock(return_value=httpx.Response(status))
+
+    with patch("app.services.googlebooks.outbound.fetch", new=fake_fetch):
+        result = await googlebooks.test_connection(sentinel)
+
+    assert result == expected
+    assert sentinel not in repr(result)
+    assert fake_fetch.await_args.kwargs["headers"] == {"X-Goog-Api-Key": sentinel}
+    assert sentinel not in fake_fetch.await_args.args[2]
+
+
+@pytest.mark.asyncio
+async def test_connection_transport_failure_does_not_expose_key(caplog):
+    sentinel = "sentinel-transport-key"
+    with patch(
+        "app.services.googlebooks.outbound.fetch",
+        new=AsyncMock(side_effect=httpx.ConnectError("offline")),
+    ):
+        result = await googlebooks.test_connection(sentinel)
+
+    assert result == {"ok": False, "message": "Connection failed — check network"}
+    assert sentinel not in repr(result)
+    assert sentinel not in caplog.text
+
+
+@pytest.mark.parametrize("status", [401, 403, 429])
+@pytest.mark.asyncio
+async def test_credentialed_lookup_preserves_controlled_failure_behavior(status):
+    fake_fetch = AsyncMock(return_value=httpx.Response(status))
+    with patch("app.services.googlebooks.outbound.fetch", new=fake_fetch):
+        assert await googlebooks.lookup("9780441172719", object(), api_key="fake-key") is None
+
+
+@pytest.mark.asyncio
+async def test_credentialed_lookup_preserves_transport_and_malformed_behavior():
+    with patch(
+        "app.services.googlebooks.outbound.fetch",
+        new=AsyncMock(side_effect=httpx.ConnectError("offline")),
+    ):
+        assert await googlebooks.lookup("9780441172719", object(), api_key="fake-key") is None
+
+    with patch(
+        "app.services.googlebooks.outbound.fetch",
+        new=AsyncMock(return_value=httpx.Response(200, content=b"not-json")),
+    ):
+        assert await googlebooks.lookup("9780441172719", object(), api_key="fake-key") is None

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -933,9 +933,10 @@ HC_IDS = {"hardcover_book_id": 42, "hardcover_edition_id": 99}
 
 def _patch_lookup(monkeypatch, result=None, raises=None, record=None):
     """Patch items_common._lookup_metadata — confirm's lazy import resolves it there."""
-    async def fake(isbn13, hc_token, client):
+    async def fake(isbn13, hc_token, client, *, google_api_key=None):
         if record is not None:
-            record.append({"isbn13": isbn13, "hc_token": hc_token})
+            record.append({"isbn13": isbn13, "hc_token": hc_token,
+                           "google_api_key": google_api_key})
         if raises:
             raise raises
         return result
@@ -968,6 +969,23 @@ class TestConfirmWithIsbn:
         assert row["owned"] == 0
         assert row["hardcover_book_id"] == 42
         assert route.called is False                  # no weak-path search
+
+    @respx.mock
+    def test_google_key_reaches_photo_intake_cascade(self, admin_client, monkeypatch):
+        calls = []
+        monkeypatch.setenv("GOOGLE_BOOKS_API_KEY", "intake-google-key")
+        _patch_lookup(
+            monkeypatch,
+            result=(FULL_META, "openlibrary", HC_IDS, False),
+            record=calls,
+        )
+        respx.get(OL_SEARCH_URL).mock(return_value=httpx.Response(200, json={"docs": []}))
+
+        admin_client.post("/api/intake/confirm", json={
+            "books": [{"title": "Dune", "isbn": ISBN13}],
+        })
+
+        assert calls[0]["google_api_key"] == "intake-google-key"
 
     @respx.mock
     def test_hardcover_token_loaded_via_get_setting(self, admin_client, monkeypatch):
@@ -1111,7 +1129,7 @@ class TestConfirmWithIsbn:
         enrich = AsyncMock(return_value=None)
         monkeypatch.setattr(items_common, "_enrich_import_covers", enrich)
 
-        async def fake(isbn13, hc_token, client):
+        async def fake(isbn13, hc_token, client, *, google_api_key=None):
             return (FULL_META, "openlibrary", {}, False) if isbn13 == ISBN13 else (None, "manual", {}, False)
         monkeypatch.setattr(items_common, "_lookup_metadata", fake)
         respx.get(OL_SEARCH_URL).mock(return_value=httpx.Response(200, json={"docs": []}))
@@ -1144,7 +1162,7 @@ class TestConfirmWithIsbn:
         from app.routers import items_common
         from tests.conftest import _insert_item as insert
 
-        async def fake(isbn13, hc_token, client):
+        async def fake(isbn13, hc_token, client, *, google_api_key=None):
             from app.database import get_db
             with get_db() as rival:
                 insert(rival, title="Dune (rival)", isbn=ISBN13, media_type="book")

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -1180,6 +1180,21 @@ class TestDnbRoutingAndLanguageCapture:
         assert metadata["description"] == "Klappentext"
         assert hc_ids["hardcover_book_id"] == 5
 
+    async def test_google_fallback_receives_optional_api_key(self):
+        from app.routers.items_common import _lookup_metadata
+
+        google = AsyncMock(return_value={"title": "Google Book"})
+        with patch("app.services.openlibrary.lookup", new=AsyncMock(return_value=None)), \
+             patch("app.services.googlebooks.lookup", new=google):
+            metadata, source, _, _ = await _lookup_metadata(
+                "9780441172719", None, None, google_api_key="google-key"
+            )
+
+        assert metadata["title"] == "Google Book"
+        assert source == "google"
+        assert google.await_args.kwargs["api_key"] == "google-key"
+        assert callable(google.await_args.kwargs["on_rate_limit"])
+
     def test_save_item_persists_language(self, db):
         from app.routers.items_common import _save_item
 

--- a/tests/test_scan_modes.py
+++ b/tests/test_scan_modes.py
@@ -254,6 +254,29 @@ class TestQuickRateMode:
         assert b"Not in your collection" in resp.content or b"not found" in resp.content
 
 
+class TestGoogleBooksCredentialPropagation:
+    def test_env_key_reaches_scan_lookup(self, admin_client, monkeypatch):
+        monkeypatch.setenv("GOOGLE_BOOKS_API_KEY", "scan-google-key")
+        lookup = AsyncMock(return_value=(None, "manual", {}, False))
+        with patch("app.routers.items_common._lookup_metadata", new=lookup), \
+             patch("app.routers.items_common._fetch_preview_cover", new=AsyncMock(return_value=None)):
+            admin_client.post("/api/scan", data={
+                "isbn": "9780000099986", "media_type": "book", "mode": "add",
+            })
+
+        assert lookup.await_args.kwargs["google_api_key"] == "scan-google-key"
+
+    def test_env_key_reaches_add_by_isbn_lookup(self, editor_client, monkeypatch):
+        monkeypatch.setenv("GOOGLE_BOOKS_API_KEY", "add-google-key")
+        lookup = AsyncMock(return_value=(None, "manual", {}, False))
+        with patch("app.routers.items_common._lookup_metadata", new=lookup):
+            editor_client.post("/api/books/add", data={
+                "isbn": "9780000099979", "media_type": "book",
+            })
+
+        assert lookup.await_args.kwargs["google_api_key"] == "add-google-key"
+
+
 class TestManualAddForm:
     """The not_found branch of scan_result.html renders the manual entry form,
     including the #19 copy-from picker and the series/location fields."""
@@ -477,7 +500,7 @@ class TestTheBarcodeOutranksTheDropdown:
     def stub_book_lookup(self, monkeypatch):
         from app.routers import items_common
 
-        async def _lookup(isbn13, hc_token, client):
+        async def _lookup(isbn13, hc_token, client, *, google_api_key=None):
             return ({"title": "A Real Novel", "authors": "Someone"}, "openlibrary", {}, False)
 
         monkeypatch.setattr(items_common, "_lookup_metadata", _lookup)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -25,6 +25,28 @@ class TestGetSetting:
         monkeypatch.setenv("HARDCOVER_TOKEN", "env-token")
         assert get_setting(db, "hardcover_token") == "env-token"
 
+    def test_google_env_var_used_when_no_db_value(self, db, monkeypatch):
+        monkeypatch.setenv("GOOGLE_BOOKS_API_KEY", "env-google-key")
+        assert get_setting(db, "google_books_api_key") == "env-google-key"
+
+    def test_google_env_var_overrides_stored_value(self, admin_client, db, monkeypatch):
+        admin_client.post(
+            "/api/settings",
+            data={"google_books_api_key": "stored-google-key"},
+            follow_redirects=False,
+        )
+        monkeypatch.setenv("GOOGLE_BOOKS_API_KEY", "env-google-key")
+        assert get_setting(db, "google_books_api_key") == "env-google-key"
+
+    def test_blank_google_env_var_uses_stored_value(self, admin_client, db, monkeypatch):
+        admin_client.post(
+            "/api/settings",
+            data={"google_books_api_key": "stored-google-key"},
+            follow_redirects=False,
+        )
+        monkeypatch.setenv("GOOGLE_BOOKS_API_KEY", "")
+        assert get_setting(db, "google_books_api_key") == "stored-google-key"
+
     def test_no_env_override_for_unknown_keys(self, db, monkeypatch):
         """Keys not in SECRET_ENV_VARS should not check env."""
         db.execute("INSERT INTO settings (key, value) VALUES ('custom_key', 'db-val')")

--- a/tests/test_settings_masking.py
+++ b/tests/test_settings_masking.py
@@ -28,13 +28,15 @@ class TestNoEcho:
         token = _save_abs(admin_client)
         admin_client.post(
             "/api/settings",
-            data={"hardcover_token": "hc-secret-xyz", "isbndb_api_key": "isbndb-secret-xyz"},
+            data={"hardcover_token": "hc-secret-xyz", "isbndb_api_key": "isbndb-secret-xyz",
+                  "google_books_api_key": "google-secret-xyz"},
             follow_redirects=False,
         )
         html = admin_client.get("/settings").text
         assert token not in html
         assert "hc-secret-xyz" not in html
         assert "isbndb-secret-xyz" not in html
+        assert "google-secret-xyz" not in html
         # Saved state is still communicated
         assert "Saved — leave blank to keep" in html
 
@@ -110,6 +112,28 @@ class TestWriteOnlySemantics:
         with get_db() as db:
             assert get_setting(db, "abs_url") == ""
             assert get_setting(db, "abs_token") == "super-secret-abs-token"
+
+    def test_google_key_is_encrypted_write_only_and_clearable(self, admin_client, db):
+        sentinel = "google-stored-secret"
+        admin_client.post(
+            "/api/settings",
+            data={"google_books_api_key": sentinel},
+            follow_redirects=False,
+        )
+        raw = db.execute(
+            "SELECT value FROM settings WHERE key = 'google_books_api_key'"
+        ).fetchone()["value"]
+        assert raw != sentinel
+        assert raw.startswith("gAAAAA")
+        assert get_setting(db, "google_books_api_key") == sentinel
+        assert sentinel not in admin_client.get("/settings").text
+
+        admin_client.post(
+            "/api/settings",
+            data={"google_books_api_key": "", "clear_google_books_api_key": "on"},
+            follow_redirects=False,
+        )
+        assert get_setting(db, "google_books_api_key") == ""
 
     def test_vision_key_keep_and_clear(self, admin_client):
         admin_client.post(
@@ -209,6 +233,7 @@ class TestEnvOnlyCredentials:
         ("data-abs-saved", ["ABS_TOKEN"]),
         ("data-abs-url-present", ["ABS_URL"]),
         ("data-hc-saved", ["HARDCOVER_TOKEN"]),
+        ("data-google-books-saved", ["GOOGLE_BOOKS_API_KEY"]),
         ("data-api-key-saved", ["ISBNDB_API_KEY"]),
         ("data-tmdb-saved", ["TMDB_API_KEY"]),
         ("data-igdb-saved", ["IGDB_CLIENT_ID", "IGDB_CLIENT_SECRET"]),
@@ -349,3 +374,34 @@ class TestStoredCredentialFallback:
                                      json={"url": "", "format": "ntfy"})
         assert resp.json()["ok"] is True
         assert send.await_args.args[0] == "https://ntfy.example/stored"
+
+    def test_google_books_test_uses_stored_key(self, admin_client):
+        admin_client.post(
+            "/api/settings",
+            data={"google_books_api_key": "google-stored"},
+            follow_redirects=False,
+        )
+        with patch(
+            "app.services.googlebooks.test_connection",
+            new=AsyncMock(return_value={"ok": True, "message": "ok"}),
+        ) as test_connection:
+            resp = admin_client.post(
+                "/api/settings/google-books/test", json={"api_key": ""}
+            )
+        assert resp.json() == {"ok": True, "message": "ok"}
+        test_connection.assert_awaited_once_with("google-stored")
+
+    def test_google_books_test_uses_env_override(self, admin_client, monkeypatch):
+        monkeypatch.setenv("GOOGLE_BOOKS_API_KEY", "google-env")
+        with patch(
+            "app.services.googlebooks.test_connection",
+            new=AsyncMock(return_value={"ok": True, "message": "ok"}),
+        ) as test_connection:
+            admin_client.post("/api/settings/google-books/test", json={"api_key": ""})
+        test_connection.assert_awaited_once_with("google-env")
+
+    def test_google_books_test_requires_admin(self, editor_client):
+        resp = editor_client.post(
+            "/api/settings/google-books/test", json={"api_key": "fake"}
+        )
+        assert resp.status_code == 403

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -170,6 +170,14 @@ class TestStoreQueue:
         item = db.execute("SELECT * FROM items WHERE isbn = '9780441013593'").fetchone()
         assert item["owned"] == 0
 
+    def test_google_key_reaches_store_metadata_lookup(self, admin_client, monkeypatch):
+        monkeypatch.setenv("GOOGLE_BOOKS_API_KEY", "store-google-key")
+        lookup = AsyncMock(return_value=(None, None, {}, False))
+        with patch("app.routers.items_common._lookup_metadata", new=lookup):
+            admin_client.post("/api/store/queue", json={"isbns": ["9780900000011"]})
+
+        assert lookup.await_args.kwargs["google_api_key"] == "store-google-key"
+
     def test_bare_add_when_lookup_fails(self, admin_client, db):
         with patch("app.routers.items_common._lookup_metadata",
                    new=AsyncMock(side_effect=Exception("network down"))):

--- a/tests/test_synopsis.py
+++ b/tests/test_synopsis.py
@@ -1,5 +1,6 @@
 """Tests for synopsis lookup and backfill (services/synopsis.py + endpoints)."""
 import json
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -19,6 +20,21 @@ def _gb_volume(title="Dune", authors=("Frank Herbert",), description="A desert p
 
 
 class TestFetchDescription:
+    @pytest.mark.asyncio
+    async def test_google_key_reaches_isbn_and_title_searches(self):
+        isbn_lookup = AsyncMock(return_value=None)
+        title_search = AsyncMock(return_value=[])
+        with patch("app.services.googlebooks.lookup", new=isbn_lookup), \
+             patch("app.services.openlibrary.search_by_title_author", new=AsyncMock(return_value=[])), \
+             patch("app.services.googlebooks.search_by_title_author", new=title_search):
+            await synopsis.fetch_description(
+                "9780441013593", "Dune", "Frank Herbert", object(),
+                google_api_key="google-key",
+            )
+
+        assert isbn_lookup.await_args.kwargs["api_key"] == "google-key"
+        assert title_search.await_args.kwargs["api_key"] == "google-key"
+
     @respx.mock
     @pytest.mark.asyncio
     async def test_google_books_isbn_first(self):


### PR DESCRIPTION
## Summary

- add optional GOOGLE_BOOKS_API_KEY and encrypted write-only Settings storage
- send configured credentials only through the X-Goog-Api-Key header for ISBN metadata, synopsis, and cover requests
- preserve anonymous Google Books behavior when no key is configured
- add an admin-only, CSRF-protected Settings test action with sanitized responses
- centralize Google Books cover requests in the existing provider service

## Compatibility

- no database schema migration
- environment configuration takes precedence over a stored Settings value, following the existing Shelf secret-setting behavior
- an empty environment value is treated as unset, so a stored key remains effective
- no provider ordering or unrelated metadata fallback behavior changes

## Verification

- 476 focused route/service/settings tests passed
- 175 high-risk credential/settings/module-size tests passed after final structural review
- all 184 Playwright E2E tests passed
- CSRF, Alpine/CSP, service-worker stamp, test badge, test-convention, and whitespace checks passed
- pip-audit found no known vulnerabilities; dependency license inventory completed
- full Windows unit run: 1,920 passed; 11 existing Windows-only failures remain in archive open-file deletion, Unix permission assertions, and worker default text encoding