### PR TITLE
Fix Hardcover ISBN-10 fallback lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Release](https://img.shields.io/github/v/release/dgahagan/shelf)](https://github.com/dgahagan/shelf/releases)
 [![Docker Pulls](https://img.shields.io/docker/pulls/dangahagan/shelf)](https://hub.docker.com/r/dangahagan/shelf)
 [![CI](https://github.com/dgahagan/shelf/actions/workflows/test.yml/badge.svg)](https://github.com/dgahagan/shelf/actions/workflows/test.yml)
-[![Unit tests](https://img.shields.io/badge/unit%20tests-1903%20passing-brightgreen)](https://github.com/dgahagan/shelf/actions/workflows/test.yml)
-[![E2E tests](https://img.shields.io/badge/e2e%20tests-202%20passing-brightgreen)](https://github.com/dgahagan/shelf/actions/workflows/test.yml)
+[![Unit tests](https://img.shields.io/badge/unit%20tests-1933%20passing-brightgreen)](https://github.com/dgahagan/shelf/actions/workflows/test.yml)
+[![E2E tests](https://img.shields.io/badge/e2e%20tests-203%20passing-brightgreen)](https://github.com/dgahagan/shelf/actions/workflows/test.yml)
 [![License: AGPL-3.0](https://img.shields.io/github/license/dgahagan/shelf)](LICENSE)
 
 A self-hosted home library catalog with barcode scanning, multi-mode scanning workflows, automatic metadata lookup, cover art, and collection management — all in a single Docker container.

--- a/app/services/hardcover.py
+++ b/app/services/hardcover.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 import httpx
 
 from app.services import outbound
+from app.services.isbn import isbn13_to_isbn10
 
 logger = logging.getLogger(__name__)
 
@@ -117,9 +118,10 @@ async def lookup_by_isbn(
     data = await _graphql(query, {"isbn": isbn}, token=token, client=client, on_rate_limit=on_rate_limit)
     if not data or not data.get("editions"):
         # Try as ISBN-10
+        isbn10 = isbn13_to_isbn10(isbn) or isbn
         query_10 = query.replace("isbn_13", "isbn_10")
         data = await _graphql(
-            query_10, {"isbn": isbn}, token=token, client=client, on_rate_limit=on_rate_limit
+            query_10, {"isbn": isbn10}, token=token, client=client, on_rate_limit=on_rate_limit
         )
         if not data or not data.get("editions"):
             return None

--- a/tests/test_outbound_clients.py
+++ b/tests/test_outbound_clients.py
@@ -352,6 +352,31 @@ class TestHardcoverGraphqlRateLimit:
         assert calls == []
 
 
+class TestHardcoverLookupByIsbnFallback:
+    @pytest.mark.parametrize(
+        ("isbn", "expected_retry"),
+        [
+            ("9780306406157", "0306406152"),
+            ("0306406152", "0306406152"),
+        ],
+    )
+    async def test_isbn10_retry_uses_the_isbn10_value(self, isbn, expected_retry):
+        attempts = []
+
+        async def graphql(query, variables, **kwargs):
+            field = "isbn_10" if "where: { isbn_10:" in query else "isbn_13"
+            attempts.append((field, variables["isbn"]))
+            return {"editions": []}
+
+        with patch("app.services.hardcover._graphql", side_effect=graphql):
+            assert await hardcover.lookup_by_isbn(isbn, AsyncMock()) is None
+
+        assert attempts == [
+            ("isbn_13", isbn),
+            ("isbn_10", expected_retry),
+        ]
+
+
 class TestHardcoverLookupByIsbnRateLimit:
     """The callback must fire from either attempt -- the ISBN-13 lookup, or
     the ISBN-10 retry that runs when the first misses. `lookup_by_isbn`


### PR DESCRIPTION
## Summary

When a Hardcover ISBN-13 lookup misses, the fallback query changes its filter to isbn_10 but currently reuses the original 13-digit value. This converts the ISBN-13 before the retry while preserving the existing behavior for callers that already provide a valid ISBN-10.

The provider order, GraphQL transport, rate-limit callback, and failure behavior are unchanged.

## Tests

- reproduced before the fix: the ISBN-10 query received 9780306406157 instead of 0306406152
- added regression coverage for converted ISBN-13 input and already-valid ISBN-10 input
- 69 ISBN and outbound-provider tests passed
- badge and outbound guard: 31 passed
- CSRF, Alpine/CSP, test-convention, service-worker stamp, module-size, compile, and diff checks passed
- complete Windows unit run exercised 1,933 tests; selected tests passed, while existing Windows archive-file, Unix-permission, and worker-encoding limitations remained

The official badge stamper was run after PR #52 merged, updating the generated counts to 1933 unit and 203 E2E tests.