### PR TITLE
Reject invalid lending notification formats

### DIFF
--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -153,7 +153,9 @@ async def update_lending_settings(
     days = lending_overdue_days.strip() or "28"
     if not days.isdigit():
         return {"ok": False, "message": "Overdue days must be a whole number"}
-    fmt = notify_format if notify_format in FORMATS else "ntfy"
+    fmt = (notify_format or "").strip()
+    if fmt not in FORMATS:
+        return {"ok": False, "message": "Unknown notification format"}
 
     with get_db() as db:
         for key, value in [

--- a/tests/test_lending_settings_boundaries.py
+++ b/tests/test_lending_settings_boundaries.py
@@ -1,0 +1,25 @@
+"""Mutation-boundary regressions for lending reminder settings."""
+
+
+def test_invalid_notify_format_rejected_without_mutating_lending_settings(admin_client, db):
+    db.execute("INSERT INTO settings (key, value) VALUES ('lending_overdue_days', '21')")
+    db.execute("INSERT INTO settings (key, value) VALUES ('notify_format', 'webhook')")
+    db.commit()
+
+    response = admin_client.post(
+        "/api/settings/lending",
+        data={
+            "lending_overdue_days": "7",
+            "notify_format": "carrier-pigeon",
+            "notify_url": "",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": False, "message": "Unknown notification format"}
+    rows = dict(
+        db.execute(
+            "SELECT key, value FROM settings WHERE key IN ('lending_overdue_days', 'notify_format')"
+        ).fetchall()
+    )
+    assert rows == {"lending_overdue_days": "21", "notify_format": "webhook"}


### PR DESCRIPTION
## What this changes

Rejects unknown `notify_format` values submitted to the lending settings endpoint instead of silently coercing them to `ntfy`.

Adds a regression test confirming that an invalid format is rejected before any lending settings are mutated.

## Why

The endpoint currently treats any unrecognised notification format as `ntfy`. A malformed or forged request can therefore change both the notification format and other lending settings while appearing valid.

The settings boundary should reject an unknown enum value rather than silently substitute a different one.

## How it was tested

The equivalent fix and regression test passed the fork's full CI workflow before being rebuilt cleanly on top of upstream `main`.

This PR branch contains only the upstream-targeted change and test; upstream CI can verify it against the current tree.

* [ ] `make test` passes
* [ ] `make test-e2e` passes
* [ ] `make checks` passes
* [ ] `make css` re-run, if templates or Tailwind classes changed

## Notes for review

This is intentionally a small boundary-validation fix.

Normal Settings UI submissions already send one of the supported formats, so there is no template/CSS change and no user-facing workflow change for valid requests.
