### PR TITLE
Reject invalid roles when creating users

### DIFF
--- a/app/routers/auth_routes.py
+++ b/app/routers/auth_routes.py
@@ -150,7 +150,7 @@ async def create_user(
     username = username.strip()
     display_name = display_name.strip() or username
     if role not in ("admin", "editor", "viewer"):
-        role = "viewer"
+        return {"ok": False, "message": "Invalid role"}
     if len(password) < 8:
         return {"ok": False, "message": "Password must be at least 8 characters"}
     if not username or len(username) < 2:

--- a/tests/test_user_create_boundaries.py
+++ b/tests/test_user_create_boundaries.py
@@ -1,0 +1,19 @@
+"""Regression coverage for user-creation request boundaries."""
+
+
+def test_create_user_rejects_invalid_role_without_creating_account(admin_client, db):
+    response = admin_client.post(
+        "/api/users",
+        data={
+            "username": "invalid-role-user",
+            "display_name": "Invalid Role",
+            "password": "correct-horse-battery-staple",
+            "role": "owner",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": False, "message": "Invalid role"}
+    assert db.execute(
+        "SELECT id FROM users WHERE username = ?", ("invalid-role-user",)
+    ).fetchone() is None


### PR DESCRIPTION
## What this changes

Rejects an unknown role supplied while creating a user instead of silently converting it to `viewer`.

Adds a regression test proving that an invalid role creates no account.

## Why

The user-creation endpoint currently treats any unrecognised role as `viewer`.

That differs from the existing user role-update endpoint, which rejects roles outside `admin`, `editor`, and `viewer` with an `Invalid role` response.

Rejecting malformed input makes the two user-management boundaries consistent and avoids accepting a request while creating an account with different permissions than were requested.

## How it was tested

The equivalent change and regression test passed the fork's full CI workflow.

This branch was rebuilt directly from current upstream `main` and contains only the one-line behaviour change and its focused regression test.

* [x] `make test` passes
* [ ] `make test-e2e` passes
* [ ] `make checks` passes
* [ ] `make css` re-run, if templates or Tailwind classes changed

## Notes for review

No normal UI behaviour changes. Shelf's user-management UI already submits only the supported roles.

This change affects malformed, stale, or manually forged requests only.
