### PR TITLE
Reject invalid share-link mutations

### DIFF
--- a/app/routers/share.py
+++ b/app/routers/share.py
@@ -7,7 +7,7 @@ field set — never locations, loans, valuations, notes, or ISBNs.
 import secrets
 
 from fastapi import APIRouter, Depends, Form, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
 from app.auth import require_role
 from app.database import get_db
@@ -53,7 +53,9 @@ async def create_share_link(
     _=Depends(require_role("admin")),
 ):
     if scope not in SCOPES:
-        scope = "wishlist"
+        return JSONResponse(
+            {"ok": False, "message": "Invalid share scope"}, status_code=400
+        )
     token = secrets.token_urlsafe(16)
     with get_db() as db:
         db.execute(
@@ -66,5 +68,9 @@ async def create_share_link(
 @router.post("/api/share/{link_id}/delete")
 async def revoke_share_link(link_id: int, _=Depends(require_role("admin"))):
     with get_db() as db:
-        db.execute("DELETE FROM share_links WHERE id = ?", (link_id,))
+        cursor = db.execute("DELETE FROM share_links WHERE id = ?", (link_id,))
+        if cursor.rowcount != 1:
+            return JSONResponse(
+                {"ok": False, "message": "Share link not found"}, status_code=404
+            )
     return RedirectResponse(url="/settings", status_code=303)

--- a/tests/test_share_links.py
+++ b/tests/test_share_links.py
@@ -37,6 +37,11 @@ class TestShareLinkLifecycle:
         client.cookies.clear()
         assert client.get(f"/share/{link['token']}").status_code == 404
 
+    def test_revoke_missing_link_404(self, admin_client):
+        resp = admin_client.post("/api/share/999999/delete", follow_redirects=False)
+        assert resp.status_code == 404
+        assert resp.json() == {"ok": False, "message": "Share link not found"}
+
     def test_viewer_cannot_create_or_revoke(self, client, viewer_user):
         from app.auth import create_token
         token = create_token(viewer_user["id"], viewer_user["username"], viewer_user["role"],
@@ -52,9 +57,18 @@ class TestShareLinkLifecycle:
         assert resp.headers.get("x-robots-tag") == "noindex"
         assert client.get("/share/bad").headers.get("x-robots-tag") == "noindex"
 
-    def test_bad_scope_defaults_to_wishlist(self, admin_client):
-        link = _create_link(admin_client, scope="everything")
-        assert link["scope"] == "wishlist"
+    def test_invalid_scope_rejected_without_creating_link(self, admin_client, db):
+        before = db.execute("SELECT COUNT(*) FROM share_links").fetchone()[0]
+        resp = admin_client.post(
+            "/api/share",
+            data={"scope": "everything", "label": "Forged"},
+            follow_redirects=False,
+        )
+        after = db.execute("SELECT COUNT(*) FROM share_links").fetchone()[0]
+
+        assert resp.status_code == 400
+        assert resp.json() == {"ok": False, "message": "Invalid share scope"}
+        assert after == before
 
 
 class TestShareScoping:


### PR DESCRIPTION
## What this changes

Makes share-link mutations reject invalid input instead of silently reporting a different or successful result.

Specifically:

* rejects unknown share scopes instead of silently converting them to `wishlist`;
* returns `404` when attempting to revoke a share link that does not exist;
* adds regression coverage proving invalid share creation does not insert a link and stale revocation does not report success.

## Why

The share-link creation endpoint currently accepts any scope value and silently changes an unknown value to `wishlist`.

That means a malformed, stale, or manually forged request can succeed while creating a different type of share link than was requested.

Similarly, revoking a nonexistent share link currently redirects as though the operation succeeded.

Rejecting these cases makes the mutation endpoints truthful while leaving the normal Settings UI and valid public share-link behaviour unchanged.

## How it was tested

The equivalent change and regression tests passed the fork's full CI workflow.

This branch was rebuilt directly from current upstream `main` and contains only changes to the share-link router and its existing test module.

* [ ] `make test` passes
* [ ] `make test-e2e` passes
* [ ] `make checks` passes
* [ ] `make css` re-run, if templates or Tailwind classes changed

## Notes for review

There is no change to valid share-link creation, public share pages, scope filtering, access control, rate limiting, or revocation of an existing link.

The behaviour change only affects invalid or stale mutation requests.
