### PR TITLE
Validate provider-backed catalogue add inputs

### DIFF
--- a/app/routers/items_catalog.py
+++ b/app/routers/items_catalog.py
@@ -78,6 +78,17 @@ async def add_game_from_search(
     """Add a video game to the collection from an IGDB search result."""
     templates = request.app.state.templates
 
+    platform = (platform or "").strip()
+    with get_db() as db:
+        valid_platforms = get_game_platforms(db)
+    if platform and platform not in valid_platforms:
+        return templates.TemplateResponse(
+            request, "fragments/scan_result.html",
+            {"status": "error", "isbn": "",
+             "message": "Unrecognised game platform — pick one and try again"},
+        )
+    platform_val = platform or None
+
     with get_db() as db:
         client_id = get_setting(db, "igdb_client_id")
         client_secret = get_setting(db, "igdb_client_secret")
@@ -97,9 +108,6 @@ async def add_game_from_search(
     loc_id = location_id if location_id and location_id > 0 else None
 
     with get_db() as db:
-        valid_platforms = get_game_platforms(db)
-        platform_val = platform if platform in valid_platforms else None
-
         # Check duplicate by title + platform
         existing = db.execute(
             "SELECT id, title FROM items WHERE title = ? AND media_type = 'video_game' AND platform = ?",
@@ -335,6 +343,25 @@ async def add_dvd_from_search(
 ):
     """Add a DVD/Blu-ray to the collection from a TMDb search result."""
     templates = request.app.state.templates
+
+    title = (title or "").strip()
+    if not title:
+        return templates.TemplateResponse(
+            request, "fragments/scan_result.html",
+            {"status": "error", "isbn": "", "message": "Title is required"},
+        )
+
+    publish_year = (publish_year or "").strip()
+    if publish_year:
+        if not publish_year.isdigit():
+            return templates.TemplateResponse(
+                request, "fragments/scan_result.html",
+                {"status": "error", "isbn": "", "message": "Invalid publish year"},
+            )
+        year = int(publish_year)
+    else:
+        year = None
+
     loc_id = location_id if location_id and location_id > 0 else None
 
     # Check duplicate by title
@@ -349,8 +376,6 @@ async def add_dvd_from_search(
             request, "fragments/scan_result.html",
             {"status": "duplicate", "isbn": "", "title": existing["title"], "item_id": existing["id"]},
         )
-
-    year = int(publish_year) if publish_year and publish_year.isdigit() else None
 
     with get_db() as db:
         item_id = insert_item(

--- a/tests/test_catalogue_add_boundaries.py
+++ b/tests/test_catalogue_add_boundaries.py
@@ -1,0 +1,57 @@
+"""Request-boundary regressions for provider-backed catalogue adds."""
+
+from app.routers import items_catalog
+
+
+def _item_count(db, *, title=None, media_type=None):
+    where = []
+    params = []
+    if title is not None:
+        where.append("title = ?")
+        params.append(title)
+    if media_type is not None:
+        where.append("media_type = ?")
+        params.append(media_type)
+    clause = " WHERE " + " AND ".join(where) if where else ""
+    return db.execute(f"SELECT COUNT(*) FROM items{clause}", params).fetchone()[0]
+
+
+def test_dvd_add_rejects_blank_title_without_inserting(editor_client, db):
+    response = editor_client.post(
+        "/api/dvds/add",
+        data={"title": "   ", "publish_year": "2024"},
+    )
+
+    assert response.status_code == 200
+    assert "Title is required" in response.text
+    assert _item_count(db, media_type="dvd") == 0
+
+
+def test_dvd_add_rejects_malformed_publish_year_without_inserting(editor_client, db):
+    response = editor_client.post(
+        "/api/dvds/add",
+        data={"title": "Bad Year DVD", "publish_year": "twenty-twenty-four"},
+    )
+
+    assert response.status_code == 200
+    assert "Invalid publish year" in response.text
+    assert _item_count(db, title="Bad Year DVD", media_type="dvd") == 0
+
+
+def test_game_add_rejects_unknown_platform_before_igdb(editor_client, db, monkeypatch):
+    monkeypatch.setattr(items_catalog, "get_setting", lambda db, key: "configured")
+
+    class _NoOutboundClient:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("IGDB HTTP client must not be created for an invalid platform")
+
+    monkeypatch.setattr(items_catalog.httpx, "AsyncClient", _NoOutboundClient)
+
+    response = editor_client.post(
+        "/api/games/add",
+        data={"igdb_id": "123", "platform": "not-a-real-platform"},
+    )
+
+    assert response.status_code == 200
+    assert "Unrecognised game platform" in response.text
+    assert _item_count(db, media_type="video_game") == 0


### PR DESCRIPTION
## Summary
- reject unknown game platforms instead of silently clearing them
- validate game platforms before any IGDB request is made
- reject blank DVD titles
- reject malformed DVD publish years instead of silently dropping them
- add focused regression coverage for all three boundaries

## Why
The provider-backed catalogue add routes currently handle malformed form values inconsistently. Invalid game platforms can be silently converted to no platform, while invalid DVD years can be silently discarded. Invalid requests should be rejected before mutation or outbound provider work.

## Testing
Adds three focused regressions covering invalid game platforms, blank DVD titles, and malformed DVD publish years.