### PR TITLE
Validate manual catalogue add inputs

### DIFF
--- a/app/routers/items.py
+++ b/app/routers/items.py
@@ -508,8 +508,20 @@ async def manual_add(request: Request, _=Depends(require_role("editor"))):
         upc_code = None
         isbn13 = isbn_svc.to_isbn13(isbn) if isbn else None
         isbn10 = isbn_svc.isbn13_to_isbn10(isbn13) if isbn13 else None
-    pub_year = form.get("publish_year")
-    platform = form.get("platform") or None
+
+    pub_year_raw = (form.get("publish_year") or "").strip()
+    if pub_year_raw:
+        try:
+            pub_year = int(pub_year_raw)
+        except (TypeError, ValueError):
+            return templates.TemplateResponse(
+                request, "fragments/scan_result.html",
+                {"status": "error", "isbn": isbn, "message": "Invalid publish year"},
+            )
+    else:
+        pub_year = None
+
+    platform = (form.get("platform") or "").strip() or None
     language = form.get("language", "").strip() or None
 
     # #19 "copy from" prefill: series_name + location_id are optional and
@@ -527,7 +539,11 @@ async def manual_add(request: Request, _=Depends(require_role("editor"))):
 
     with get_db() as db:
         if platform and platform not in get_game_platforms(db):
-            platform = None
+            return templates.TemplateResponse(
+                request, "fragments/scan_result.html",
+                {"status": "error", "isbn": isbn,
+                 "message": "Unrecognised game platform — pick one and try again"},
+            )
         if location_id is not None:
             loc_row = db.execute("SELECT id FROM locations WHERE id = ?", (location_id,)).fetchone()
             if not loc_row:
@@ -544,7 +560,7 @@ async def manual_add(request: Request, _=Depends(require_role("editor"))):
                     upc=upc_code,
                     media_type=media_type,
                     publisher=form.get("publisher"),
-                    publish_year=int(pub_year) if pub_year else None,
+                    publish_year=pub_year,
                     platform=platform,
                     series_name=series_name,
                     location_id=location_id,
@@ -1206,7 +1222,6 @@ async def test_igdb_key(request: Request, _=Depends(require_role("admin"))):
         return {"ok": False, "message": "Both Client ID and Client Secret are required"}
     async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
         return await igdb.test_credentials(client_id, client_secret, client)
-
 
 
 

--- a/tests/test_manual_add_boundaries.py
+++ b/tests/test_manual_add_boundaries.py
@@ -1,0 +1,33 @@
+"""Request-boundary regressions for manual catalogue adds."""
+
+
+def _item_count(db, *, title=None):
+    if title is None:
+        return db.execute("SELECT COUNT(*) FROM items").fetchone()[0]
+    return db.execute("SELECT COUNT(*) FROM items WHERE title = ?", (title,)).fetchone()[0]
+
+
+def test_manual_add_rejects_malformed_publish_year_without_inserting(editor_client, db):
+    response = editor_client.post(
+        "/api/items/manual",
+        data={"title": "Bad Year Manual", "publish_year": "nineteen-eighty-four"},
+    )
+
+    assert response.status_code == 200
+    assert "Invalid publish year" in response.text
+    assert _item_count(db, title="Bad Year Manual") == 0
+
+
+def test_manual_add_rejects_unknown_platform_without_inserting(editor_client, db):
+    response = editor_client.post(
+        "/api/items/manual",
+        data={
+            "title": "Bad Platform Manual",
+            "media_type": "video_game",
+            "platform": "not-a-real-platform",
+        },
+    )
+
+    assert response.status_code == 200
+    assert "Unrecognised game platform" in response.text
+    assert _item_count(db, title="Bad Platform Manual") == 0


### PR DESCRIPTION
## What this changes

Makes manual catalogue adds reject malformed input instead of erroring or silently rewriting it.

Specifically:

- rejects malformed publish years before insertion instead of allowing the integer conversion to raise a server error;
- rejects unknown game platforms instead of silently clearing the submitted platform;
- adds regression coverage proving both invalid requests create no catalogue item.

## Why

The manual-add endpoint currently converts `publish_year` with `int(...)` during insertion, so a malformed value can become a server error.

It also silently changes an unknown submitted game platform to no platform at all. A malformed, stale, or manually forged request can therefore succeed while storing different catalogue data than was requested.

Rejecting these cases at the request boundary makes the mutation truthful while leaving normal manual-add behaviour unchanged.

## How it was tested

The equivalent change and regression tests passed the fork's full CI workflow.

This branch was rebuilt directly from current upstream `main` and contains only the manual-add route change and its focused regression test module.

- [ ] `make test` passes
- [ ] `make test-e2e` passes
- [ ] `make checks` passes
- [ ] `make css` re-run, if templates or Tailwind classes changed

## Notes for review

There is no change to valid manual catalogue adds, ISBN/UPC handling, duplicate detection, cover handling, locations, or supported game platforms.

The behaviour change only affects malformed publish years and unknown platform values.
