### PR TITLE
Reject invalid Hardcover sync intervals

### DIFF
--- a/app/routers/hardcover.py
+++ b/app/routers/hardcover.py
@@ -5,7 +5,7 @@ import re
 
 import httpx
 from fastapi import APIRouter, Depends, Form, Request
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from starlette.responses import StreamingResponse
 
 from app.auth import require_role
@@ -140,7 +140,9 @@ async def add_hardcover_to_shelf(request: Request, _=Depends(require_role("edito
 async def set_hardcover_schedule(interval: str = Form("off"), _=Depends(require_role("admin"))):
     """Set the Hardcover sync schedule."""
     if interval not in ("off", "daily", "weekly"):
-        interval = "off"
+        return JSONResponse(
+            {"ok": False, "message": "Invalid sync interval"}, status_code=400
+        )
     with get_db() as db:
         db.execute(
             "INSERT INTO settings (key, value) VALUES ('hc_sync_interval', ?) "

--- a/tests/test_hardcover_schedule_validation.py
+++ b/tests/test_hardcover_schedule_validation.py
@@ -1,0 +1,23 @@
+"""Regression coverage for Hardcover schedule mutation boundaries."""
+
+
+def test_hardcover_schedule_rejects_invalid_interval_without_disabling_sync(
+    admin_client, db
+):
+    db.execute(
+        "INSERT INTO settings (key, value) VALUES ('hc_sync_interval', 'daily')"
+    )
+    db.commit()
+
+    response = admin_client.post(
+        "/api/hardcover/schedule",
+        data={"interval": "hourly"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"ok": False, "message": "Invalid sync interval"}
+    stored = db.execute(
+        "SELECT value FROM settings WHERE key = 'hc_sync_interval'"
+    ).fetchone()["value"]
+    assert stored == "daily"


### PR DESCRIPTION
## What this changes

Rejects unknown Hardcover sync schedule values instead of silently converting them to `off`.

Specifically:

- accepts the existing supported values `off`, `daily`, and `weekly`;
- returns HTTP 400 for any other interval;
- preserves the currently stored schedule when an invalid value is submitted;
- adds a focused regression proving an invalid request cannot disable an existing schedule.

## Why

The Hardcover schedule endpoint currently treats every unrecognised interval as `off` and then saves it.

That means a malformed, stale, or manually forged request such as `interval=hourly` can silently disable an existing daily or weekly sync schedule while returning the normal success redirect.

Rejecting the invalid value before mutation makes the endpoint truthful and keeps the existing schedule intact.

## How it was tested

The equivalent change and regression test passed the fork's full CI workflow.

This branch was rebuilt directly from current upstream `main` as one commit and contains only the Hardcover schedule route change and its focused regression test.

- [ ] `make test` passes
- [ ] `make test-e2e` passes
- [ ] `make checks` passes
- [ ] `make css` re-run, if templates or Tailwind classes changed

## Notes for review

There is no change to normal Hardcover scheduling behaviour. The supported `off`, `daily`, and `weekly` values continue to use the existing redirect and persistence path.

The behaviour change affects unsupported interval values only.
