### PR TITLE
Validate Audiobookshelf request boundaries

### DIFF
--- a/app/routers/sync.py
+++ b/app/routers/sync.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, Depends, Request, Form
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from starlette.responses import StreamingResponse
 
 from app.auth import require_role
@@ -34,15 +34,26 @@ router = APIRouter(prefix="/api/sync", dependencies=[Depends(require_role("admin
 @router.post("/audiobookshelf/test")
 async def test_audiobookshelf(request: Request):
     """Test whether ABS URL and token are valid. Accepts values from POST body or falls back to DB."""
-    # Try to read from request body first (user may not have saved yet)
-    url = ""
-    token = ""
+    # Try to read from request body first (user may not have saved yet).
+    # Empty or absent values deliberately fall back to the stored setting, but
+    # a supplied value must still have the request shape the UI/API promises.
     try:
         body = await request.json()
-        url = (body.get("url") or "").strip().rstrip("/")
-        token = (body.get("token") or "").strip()
     except Exception:
-        pass
+        body = {}
+    if body is None:
+        body = {}
+    if not isinstance(body, dict):
+        return {"ok": False, "message": "Invalid request body"}
+
+    raw_url = body.get("url")
+    raw_token = body.get("token")
+    if ((raw_url is not None and not isinstance(raw_url, str)) or
+            (raw_token is not None and not isinstance(raw_token, str))):
+        return {"ok": False, "message": "Invalid request body"}
+
+    url = (raw_url or "").strip().rstrip("/")
+    token = (raw_token or "").strip()
 
     # Fall back to database (with env var override) if not provided in body
     if not url or not token:
@@ -108,9 +119,14 @@ async def save_abs_libraries(request: Request):
     """Save which ABS libraries to sync. Body: {excluded: [library_id, ...]}."""
     try:
         body = await request.json()
-        excluded = [str(x) for x in (body.get("excluded") or [])]
+        raw_excluded = body.get("excluded") or []
     except Exception:
         return {"ok": False, "message": "Invalid request body"}
+    if not isinstance(raw_excluded, list) or not all(
+        isinstance(value, str) for value in raw_excluded
+    ):
+        return {"ok": False, "message": "Invalid request body"}
+    excluded = raw_excluded
 
     with get_db() as db:
         db.execute(
@@ -253,7 +269,9 @@ async def sync_audiobookshelf_stream(request: Request):
 async def set_sync_schedule(interval: str = Form("off")):
     """Set the Audiobookshelf sync schedule. Values: off, daily, weekly."""
     if interval not in ("off", "daily", "weekly"):
-        interval = "off"
+        return JSONResponse(
+            {"ok": False, "message": "Invalid sync interval"}, status_code=400
+        )
     with get_db() as db:
         db.execute(
             "INSERT INTO settings (key, value) VALUES ('abs_sync_interval', ?) "

--- a/tests/test_abs_library_selection_validation.py
+++ b/tests/test_abs_library_selection_validation.py
@@ -1,0 +1,43 @@
+"""Regression coverage for Audiobookshelf settings mutation boundaries."""
+
+
+def test_abs_library_selection_rejects_non_list_without_mutating_setting(
+    admin_client, db
+):
+    db.execute(
+        "INSERT INTO settings (key, value) VALUES ('abs_excluded_libraries', ?)",
+        ('[\"keep-me\"]',),
+    )
+    db.commit()
+
+    for excluded in ("lib_junk", 123, {"id": "lib_junk"}):
+        response = admin_client.post(
+            "/api/sync/audiobookshelf/libraries",
+            json={"excluded": excluded},
+        )
+
+        assert response.json() == {"ok": False, "message": "Invalid request body"}
+        stored = db.execute(
+            "SELECT value FROM settings WHERE key = 'abs_excluded_libraries'"
+        ).fetchone()["value"]
+        assert stored == '[\"keep-me\"]'
+
+
+def test_abs_schedule_rejects_invalid_interval_without_disabling_sync(admin_client, db):
+    db.execute(
+        "INSERT INTO settings (key, value) VALUES ('abs_sync_interval', 'daily')"
+    )
+    db.commit()
+
+    response = admin_client.post(
+        "/api/sync/audiobookshelf/schedule",
+        data={"interval": "hourly"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"ok": False, "message": "Invalid sync interval"}
+    stored = db.execute(
+        "SELECT value FROM settings WHERE key = 'abs_sync_interval'"
+    ).fetchone()["value"]
+    assert stored == "daily"

--- a/tests/test_abs_test_request_validation.py
+++ b/tests/test_abs_test_request_validation.py
@@ -1,0 +1,33 @@
+"""Request-boundary regressions for the Audiobookshelf connection test."""
+
+from app.routers import sync
+
+
+def _set_setting(db, key, value):
+    db.execute(
+        "INSERT INTO settings (key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (key, value),
+    )
+    db.commit()
+
+
+class _NoOutboundClient:
+    def __init__(self, *args, **kwargs):
+        raise AssertionError("malformed ABS test input must not make an outbound request")
+
+
+def test_abs_test_rejects_non_string_fields_before_saved_fallback(
+    admin_client, db, monkeypatch
+):
+    _set_setting(db, "abs_url", "http://saved.example:13378")
+    _set_setting(db, "abs_token", "saved-token")
+    monkeypatch.setattr(sync.httpx, "AsyncClient", _NoOutboundClient)
+
+    for payload in (
+        {"url": 123, "token": "typed-token"},
+        {"url": "http://typed.example:13378", "token": 123},
+    ):
+        resp = admin_client.post("/api/sync/audiobookshelf/test", json=payload)
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": False, "message": "Invalid request body"}


### PR DESCRIPTION
## Summary
- reject malformed Audiobookshelf connection-test URL/token values before saved-credential fallback
- reject malformed excluded-library selections instead of coercing them
- reject unsupported sync intervals instead of silently disabling sync
- add focused regressions proving invalid requests do not mutate settings or make unintended outbound requests

## Testing
Rebuilt as one commit directly from upstream main. Combines two previously full-CI-tested fork fixes that touch the same Audiobookshelf request boundary.