### PR TITLE
Validate valuation credential-test requests

### DIFF
--- a/app/routers/valuation.py
+++ b/app/routers/valuation.py
@@ -18,15 +18,34 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api")
 
 
+async def _optional_test_key(request: Request) -> tuple[str | None, dict | None]:
+    """Read an optional string key from a credential-test JSON body.
+
+    Missing, null, or empty values preserve the masked-field fallback to the
+    configured credential. A supplied value with the wrong JSON shape is a
+    malformed request and must not silently test a different saved key.
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    if body is None:
+        body = {}
+    if not isinstance(body, dict):
+        return None, {"ok": False, "message": "Invalid request body"}
+
+    raw_key = body.get("key")
+    if raw_key is not None and not isinstance(raw_key, str):
+        return None, {"ok": False, "message": "Invalid request body"}
+    return (raw_key or "").strip(), None
+
+
 @router.post("/valuate/test-key")
 async def test_isbndb_key(request: Request, _=Depends(require_role("admin"))):
     """Test whether an ISBNdb API key is valid. Accepts key from POST body or falls back to DB."""
-    api_key = ""
-    try:
-        body = await request.json()
-        api_key = (body.get("key") or "").strip()
-    except Exception:
-        pass
+    api_key, request_error = await _optional_test_key(request)
+    if request_error:
+        return request_error
 
     if not api_key:
         with get_db() as db:
@@ -57,12 +76,9 @@ async def test_isbndb_key(request: Request, _=Depends(require_role("admin"))):
 @router.post("/tmdb/test-key")
 async def test_tmdb_key(request: Request, _=Depends(require_role("admin"))):
     """Test whether a TMDb API key is valid. Accepts key from POST body or falls back to DB."""
-    api_key = ""
-    try:
-        body = await request.json()
-        api_key = (body.get("key") or "").strip()
-    except Exception:
-        pass
+    api_key, request_error = await _optional_test_key(request)
+    if request_error:
+        return request_error
 
     if not api_key:
         # get_setting, not get_all_settings: the latter returns only keys that

--- a/tests/test_valuation_test_request_validation.py
+++ b/tests/test_valuation_test_request_validation.py
@@ -1,0 +1,32 @@
+"""Request-boundary regressions for ISBNdb and TMDb credential tests."""
+
+from app.routers import valuation
+
+
+class _NoOutboundClient:
+    def __init__(self, *args, **kwargs):
+        raise AssertionError("malformed test-key input must not make an outbound request")
+
+
+def test_isbndb_test_rejects_non_string_key_before_configured_fallback(
+    admin_client, monkeypatch
+):
+    monkeypatch.setenv("ISBNDB_API_KEY", "configured-isbndb-key")
+    monkeypatch.setattr(valuation.httpx, "AsyncClient", _NoOutboundClient)
+
+    response = admin_client.post("/api/valuate/test-key", json={"key": 123})
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": False, "message": "Invalid request body"}
+
+
+def test_tmdb_test_rejects_non_string_key_before_configured_fallback(
+    admin_client, monkeypatch
+):
+    monkeypatch.setenv("TMDB_API_KEY", "configured-tmdb-key")
+    monkeypatch.setattr(valuation.httpx, "AsyncClient", _NoOutboundClient)
+
+    response = admin_client.post("/api/tmdb/test-key", json={"key": 123})
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": False, "message": "Invalid request body"}


### PR DESCRIPTION
## Summary
- reject malformed ISBNdb and TMDb credential-test request bodies and non-string keys
- preserve blank/missing key fallback to configured credentials
- ensure invalid supplied values cannot silently test saved credentials
- add focused no-outbound regressions

## Testing
Rebuilt as one commit directly from upstream main from the previously full-CI-tested fork change.