### PR TITLE
Validate settings integration-test requests

### DIFF
--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -77,7 +77,10 @@ async def test_google_books(request: Request):
     if not isinstance(body, dict):
         return {"ok": False, "message": "Invalid request"}
 
-    api_key = (body.get("api_key") or "").strip()
+    raw_api_key = body.get("api_key")
+    if raw_api_key is not None and not isinstance(raw_api_key, str):
+        return {"ok": False, "message": "Invalid request"}
+    api_key = (raw_api_key or "").strip()
     if not api_key:
         with get_db() as db:
             api_key = get_setting(db, "google_books_api_key")
@@ -216,8 +219,18 @@ async def notify_test(request: Request):
         body = await request.json()
     except Exception:
         return {"ok": False, "message": "Invalid request"}
-    url = (body.get("url") or "").strip()
-    fmt = body.get("format") or "ntfy"
+    if not isinstance(body, dict):
+        return {"ok": False, "message": "Invalid request"}
+
+    raw_url = body.get("url")
+    raw_fmt = body.get("format")
+    if (
+        (raw_url is not None and not isinstance(raw_url, str))
+        or (raw_fmt is not None and not isinstance(raw_fmt, str))
+    ):
+        return {"ok": False, "message": "Invalid request"}
+    url = (raw_url or "").strip()
+    fmt = raw_fmt or "ntfy"
     if not url:
         # Masked field posts empty — test the stored URL instead
         from app.database import get_setting

--- a/tests/test_settings_request_validation.py
+++ b/tests/test_settings_request_validation.py
@@ -1,0 +1,8 @@
+"""Regression coverage for Settings JSON request boundaries."""
+
+
+def test_notify_test_rejects_non_object_json(admin_client):
+    response = admin_client.post("/api/settings/notify-test", json=[])
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": False, "message": "Invalid request"}

--- a/tests/test_settings_test_request_validation.py
+++ b/tests/test_settings_test_request_validation.py
@@ -1,0 +1,43 @@
+"""Request-boundary regressions for settings integration tests."""
+
+from app.services import googlebooks, notify
+
+
+async def _unexpected_outbound(*args, **kwargs):
+    raise AssertionError("malformed settings test input must not make an outbound request")
+
+
+def test_google_books_test_rejects_non_string_api_key(admin_client, monkeypatch):
+    monkeypatch.setattr(googlebooks, "test_connection", _unexpected_outbound)
+
+    response = admin_client.post(
+        "/api/settings/google-books/test",
+        json={"api_key": 123},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": False, "message": "Invalid request"}
+
+
+def test_notify_test_rejects_non_string_url(admin_client, monkeypatch):
+    monkeypatch.setattr(notify, "send_notification", _unexpected_outbound)
+
+    response = admin_client.post(
+        "/api/settings/notify-test",
+        json={"url": 123, "format": "ntfy"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": False, "message": "Invalid request"}
+
+
+def test_notify_test_rejects_non_string_format(admin_client, monkeypatch):
+    monkeypatch.setattr(notify, "send_notification", _unexpected_outbound)
+
+    response = admin_client.post(
+        "/api/settings/notify-test",
+        json={"url": "https://notify.invalid/topic", "format": 123},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": False, "message": "Invalid request"}


### PR DESCRIPTION
## Summary
- reject non-object notification-test JSON
- reject non-string notification URL/format values
- reject non-string Google Books API-key values
- preserve valid masked-field/configured-credential fallback
- add focused regressions proving malformed requests do not perform outbound work

## Testing
Rebuilt as one commit directly from upstream main from two previously full-CI-tested fork fixes on the same Settings request surface.