### PR TITLE
Harden Store queue request and ISBN boundaries

### DIFF
--- a/app/routers/store.py
+++ b/app/routers/store.py
@@ -96,6 +96,8 @@ async def store_queue(request: Request, _=Depends(require_role("editor"))):
         body = await request.json()
     except Exception:
         return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+    if not isinstance(body, dict):
+        return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
     isbns = body.get("isbns")
     if not isinstance(isbns, list) or not all(isinstance(x, str) for x in isbns):
         return JSONResponse({"error": "isbns must be a list of strings"}, status_code=400)
@@ -109,15 +111,17 @@ async def store_queue(request: Request, _=Depends(require_role("editor"))):
     results = []
     async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
         for raw in isbns:
-            isbn13 = isbn_svc.to_isbn13(raw)
-            if not isbn13:
+            pair = isbn_svc.canonical_isbn_pair(raw)
+            if pair is None:
                 results.append({"isbn": raw, "status": "invalid"})
                 continue
+            isbn13, isbn10 = pair
 
             with get_db() as db:
                 existing = db.execute(
-                    "SELECT id, title FROM items WHERE isbn = ? AND media_type = 'book'",
-                    (isbn13,),
+                    "SELECT id, title FROM items WHERE media_type = 'book' AND "
+                    "(isbn = ? OR (? IS NOT NULL AND isbn10 = ?))",
+                    (isbn13, isbn10, isbn10),
                 ).fetchone()
             if existing:
                 results.append({
@@ -165,12 +169,13 @@ async def store_queue(request: Request, _=Depends(require_role("editor"))):
                 except Exception:
                     logger.exception("Store queue: save failed for %s, falling back to bare add", isbn13)
 
-            # Bare fallback — never lose a scan
+            # Bare fallback — never lose a valid ISBN scan
             with get_db() as db:
                 item_id = insert_item(
                     db,
                     title=f"Unknown — ISBN {isbn13}",
                     isbn=isbn13,
+                    isbn10=isbn10,
                     media_type="book",
                     owned=0,
                     source="store_queue",

--- a/tests/e2e/test_store_pwa.py
+++ b/tests/e2e/test_store_pwa.py
@@ -20,7 +20,7 @@ pytestmark = pytest.mark.e2e
 
 OWNED_ISBN = "9780901000018"
 WISHLIST_ISBN = "9780901000025"
-UNKNOWN_ISBN = "9780901000032"
+UNKNOWN_ISBN = "9780901000033"
 
 
 def _login(live_server, ctx, setup_admin):
@@ -70,11 +70,10 @@ def test_offline_verdicts_and_queue_flush(live_server, browser, setup_admin):
         expect(pg.get_by_test_id("verdict")).to_contain_text("NOT IN LIBRARY")
         expect(pg.get_by_test_id("queue-count")).to_have_text("1")
 
-        # Back online: flush the queue (fake ISBN -> lookup fails -> bare
-        # wishlist add; the scan must never be lost)
-        ctx.set_offline(False)
+        # Going back online automatically flushes the queue. Observe that
+        # request rather than racing the auto-flush with a manual button click.
         with pg.expect_response("**/api/store/queue") as resp_info:
-            pg.get_by_test_id("sync-now").click()
+            ctx.set_offline(False)
         result = resp_info.value.json()["results"][0]
         assert result["status"] in ("wishlisted", "added_bare"), result
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -174,7 +174,7 @@ class TestStoreQueue:
         monkeypatch.setenv("GOOGLE_BOOKS_API_KEY", "store-google-key")
         lookup = AsyncMock(return_value=(None, None, {}, False))
         with patch("app.routers.items_common._lookup_metadata", new=lookup):
-            admin_client.post("/api/store/queue", json={"isbns": ["9780900000011"]})
+            admin_client.post("/api/store/queue", json={"isbns": ["9780900000010"]})
 
         assert lookup.await_args.kwargs["google_api_key"] == "store-google-key"
 
@@ -193,7 +193,7 @@ class TestStoreQueue:
     def test_bare_add_when_nothing_found(self, admin_client, db):
         with patch("app.routers.items_common._lookup_metadata",
                    new=AsyncMock(return_value=(None, None, {}, False))):
-            resp = admin_client.post("/api/store/queue", json={"isbns": ["9780900000011"]})
+            resp = admin_client.post("/api/store/queue", json={"isbns": ["9780900000010"]})
         assert resp.json()["results"][0]["status"] == "added_bare"
 
     def test_duplicate_reported(self, admin_client, db):

--- a/tests/test_store_isbn_boundary.py
+++ b/tests/test_store_isbn_boundary.py
@@ -1,0 +1,39 @@
+"""Regression coverage for Store queue ISBN persistence boundaries."""
+
+from unittest.mock import AsyncMock, patch
+
+
+def test_store_queue_rejects_bad_checksum_before_lookup(admin_client, db):
+    lookup = AsyncMock()
+    with patch("app.routers.items_common._lookup_metadata", new=lookup):
+        response = admin_client.post(
+            "/api/store/queue",
+            json={"isbns": ["9780441172718"]},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["results"] == [
+        {"isbn": "9780441172718", "status": "invalid"}
+    ]
+    lookup.assert_not_awaited()
+    assert db.execute("SELECT COUNT(*) FROM items").fetchone()[0] == 0
+
+
+def test_store_queue_isbn10_bare_add_persists_canonical_pair(admin_client, db):
+    with patch(
+        "app.routers.items_common._lookup_metadata",
+        new=AsyncMock(return_value=(None, None, {}, False)),
+    ):
+        response = admin_client.post(
+            "/api/store/queue",
+            json={"isbns": ["0441172717"]},
+        )
+
+    result = response.json()["results"][0]
+    assert result["status"] == "added_bare"
+    assert result["isbn"] == "9780441172719"
+    row = db.execute(
+        "SELECT isbn, isbn10 FROM items WHERE id = ?", (result["item_id"],)
+    ).fetchone()
+    assert row["isbn"] == "9780441172719"
+    assert row["isbn10"] == "0441172717"

--- a/tests/test_store_request_validation.py
+++ b/tests/test_store_request_validation.py
@@ -1,0 +1,9 @@
+"""Regression coverage for Store queue request-shape validation."""
+
+
+def test_store_queue_rejects_non_object_json(admin_client):
+    for body in ([], "not-an-object", None):
+        response = admin_client.post("/api/store/queue", json=body)
+
+        assert response.status_code == 400
+        assert response.json() == {"error": "Invalid JSON body"}


### PR DESCRIPTION
## Summary
- reject valid JSON bodies that are not objects
- require checksum-valid ISBNs before metadata lookup or persistence
- canonicalise ISBN-10 input to ISBN-13 while retaining the ISBN-10 pair
- detect duplicates through either canonical ISBN representation
- keep invalid queued scans as invalid instead of creating bare wishlist rows
- correct Store test fixtures to checksum-valid ISBNs

## Testing
Rebuilt as one commit directly from upstream main from two previously full-CI-tested Store boundary fixes.