### PR TITLE
Validate location administration boundaries

### DIFF
--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends, Request, Form
+import sqlite3
+
+from fastapi import APIRouter, Depends, Form
 from fastapi.responses import RedirectResponse
 
 from app.auth import require_role
@@ -7,29 +9,62 @@ from app.database import get_db
 router = APIRouter(prefix="/api/locations", dependencies=[Depends(require_role("admin"))])
 
 
+def _settings_error(code: str) -> RedirectResponse:
+    """Return to Settings with one fixed location-error code."""
+    return RedirectResponse(url=f"/settings?location_error={code}", status_code=303)
+
+
 @router.post("")
 async def create_location(name: str = Form(...), sort_order: int = Form(0)):
-    with get_db() as db:
-        db.execute(
-            "INSERT INTO locations (name, sort_order) VALUES (?, ?)",
-            (name.strip(), sort_order),
-        )
+    name = name.strip()
+    if not name:
+        return _settings_error("blank")
+
+    try:
+        with get_db() as db:
+            db.execute(
+                "INSERT INTO locations (name, sort_order) VALUES (?, ?)",
+                (name, sort_order),
+            )
+    except sqlite3.IntegrityError:
+        # `locations.name` is UNIQUE. Convert a stale/duplicate form submit to
+        # a normal Settings error instead of leaking a database exception.
+        return _settings_error("duplicate")
+
     return RedirectResponse(url="/settings", status_code=303)
 
 
 @router.post("/{location_id}/update")
 async def update_location(location_id: int, name: str = Form(...), sort_order: int = Form(0)):
-    with get_db() as db:
-        db.execute(
-            "UPDATE locations SET name = ?, sort_order = ? WHERE id = ?",
-            (name.strip(), sort_order, location_id),
-        )
+    name = name.strip()
+    if not name:
+        return _settings_error("blank")
+
+    try:
+        with get_db() as db:
+            exists = db.execute(
+                "SELECT 1 FROM locations WHERE id = ?", (location_id,)
+            ).fetchone()
+            if not exists:
+                return _settings_error("missing")
+            db.execute(
+                "UPDATE locations SET name = ?, sort_order = ? WHERE id = ?",
+                (name, sort_order, location_id),
+            )
+    except sqlite3.IntegrityError:
+        return _settings_error("duplicate")
+
     return RedirectResponse(url="/settings", status_code=303)
 
 
 @router.post("/{location_id}/delete")
 async def delete_location(location_id: int):
     with get_db() as db:
+        exists = db.execute(
+            "SELECT 1 FROM locations WHERE id = ?", (location_id,)
+        ).fetchone()
+        if not exists:
+            return _settings_error("missing")
         db.execute("UPDATE items SET location_id = NULL WHERE location_id = ?", (location_id,))
         db.execute("DELETE FROM locations WHERE id = ?", (location_id,))
     return RedirectResponse(url="/settings", status_code=303)

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -4,6 +4,21 @@
 <div class="max-w-2xl mx-auto" x-data="settingsTabs">
     <h1 class="text-2xl font-bold mb-6">Settings</h1>
 
+    {# Known codes only: never reflect arbitrary query-string text. #}
+    {% set location_error = request.query_params.get('location_error') %}
+    {% if location_error in ('blank', 'duplicate', 'missing') %}
+    <div data-testid="location-error-banner"
+         class="bg-shelf-bg text-shelf-error border border-shelf-border rounded-lg px-4 py-2 text-sm mb-6">
+        {% if location_error == 'blank' %}
+        Location name is required.
+        {% elif location_error == 'duplicate' %}
+        A location with that name already exists.
+        {% else %}
+        That location no longer exists.
+        {% endif %}
+    </div>
+    {% endif %}
+
     <!-- Tab Bar -->
     <div class="flex gap-1 mb-6 border-b border-shelf-border">
         <button @click="setTab('library')" data-testid="tab-library"

--- a/tests/test_location_delete_boundary.py
+++ b/tests/test_location_delete_boundary.py
@@ -1,0 +1,11 @@
+"""Regression coverage for location-deletion target truthfulness."""
+
+
+def test_delete_missing_location_reports_settings_error(admin_client):
+    response = admin_client.post(
+        "/api/locations/999999/delete",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/settings?location_error=missing"

--- a/tests/test_location_validation.py
+++ b/tests/test_location_validation.py
@@ -1,0 +1,79 @@
+"""Regression coverage for Settings location mutations."""
+
+from tests.conftest import _insert_location
+
+
+def test_blank_location_name_is_rejected(admin_client, db):
+    response = admin_client.post(
+        "/api/locations",
+        data={"name": "   "},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/settings?location_error=blank"
+    assert db.execute("SELECT COUNT(*) FROM locations").fetchone()[0] == 0
+
+
+def test_duplicate_location_name_is_a_settings_error(admin_client, db):
+    _insert_location(db, "Office")
+    db.commit()
+
+    response = admin_client.post(
+        "/api/locations",
+        data={"name": "Office"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/settings?location_error=duplicate"
+    assert db.execute(
+        "SELECT COUNT(*) FROM locations WHERE name = 'Office'"
+    ).fetchone()[0] == 1
+
+
+def test_update_missing_location_is_reported(admin_client):
+    response = admin_client.post(
+        "/api/locations/999999/update",
+        data={"name": "Gone"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/settings?location_error=missing"
+
+
+def test_update_cannot_collide_with_existing_name(admin_client, db):
+    first = _insert_location(db, "Office")
+    second = _insert_location(db, "Bedroom")
+    db.commit()
+
+    response = admin_client.post(
+        f"/api/locations/{second}/update",
+        data={"name": "Office"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/settings?location_error=duplicate"
+    row = db.execute("SELECT name FROM locations WHERE id = ?", (second,)).fetchone()
+    assert row["name"] == "Bedroom"
+    assert first != second
+
+
+def test_known_location_error_code_renders_fixed_banner(admin_client):
+    response = admin_client.get("/settings?location_error=duplicate")
+
+    assert response.status_code == 200
+    assert 'data-testid="location-error-banner"' in response.text
+    assert "A location with that name already exists." in response.text
+
+
+def test_unknown_location_error_code_is_not_reflected(admin_client):
+    response = admin_client.get(
+        "/settings?location_error=%3Cscript%3Ealert(1)%3C%2Fscript%3E"
+    )
+
+    assert response.status_code == 200
+    assert 'data-testid="location-error-banner"' not in response.text
+    assert "alert(1)" not in response.text


### PR DESCRIPTION
## Summary
- reject blank and duplicate location names with safe Settings feedback
- report stale update targets instead of database errors
- make deletion of a nonexistent location report failure instead of success
- render only fixed known location error messages
- add focused create/update/delete regression coverage

## Testing
Rebuilt as one commit directly from upstream main from the previously full-CI-tested location CRUD fixes.