### PR TITLE
Make tag removal truthful

### DIFF
--- a/app/routers/tags.py
+++ b/app/routers/tags.py
@@ -73,11 +73,19 @@ async def add_tag(request: Request, item_id: int, name: str = Form(...),
 async def remove_tag(request: Request, item_id: int, tag_id: int,
                      _=Depends(require_role("editor"))):
     with get_db() as db:
-        db.execute(
+        item = db.execute("SELECT id FROM items WHERE id = ?", (item_id,)).fetchone()
+        if not item:
+            return HTMLResponse("Item not found", status_code=404)
+
+        deleted = db.execute(
             "DELETE FROM item_tags WHERE item_id = ? AND tag_id = ?",
             (item_id, tag_id),
         )
-        # Garbage-collect orphaned tags so the Browse dropdown stays clean
+        if deleted.rowcount != 1:
+            return HTMLResponse("Tag not found on item", status_code=404)
+
+        # Garbage-collect orphaned tags so the Browse dropdown stays clean,
+        # but only after an association was actually removed.
         db.execute(
             "DELETE FROM tags WHERE id = ? "
             "AND NOT EXISTS (SELECT 1 FROM item_tags WHERE tag_id = ?)",

--- a/tests/test_tag_boundaries.py
+++ b/tests/test_tag_boundaries.py
@@ -1,0 +1,32 @@
+"""Regression coverage for tag-removal request boundaries."""
+
+from tests.conftest import _insert_item
+
+
+def test_remove_tag_rejects_missing_item(admin_client):
+    response = admin_client.delete("/api/items/999999/tags/999999")
+
+    assert response.status_code == 404
+    assert response.text == "Item not found"
+
+
+def test_remove_tag_rejects_tag_not_attached_to_item(admin_client, db):
+    target_id = _insert_item(db, title="Target", isbn="9780000999609")
+    other_id = _insert_item(db, title="Other", isbn="9780000999616")
+    db.execute("INSERT INTO tags (name) VALUES ('shared')")
+    tag_id = db.execute("SELECT id FROM tags WHERE name = 'shared'").fetchone()["id"]
+    db.execute(
+        "INSERT INTO item_tags (item_id, tag_id) VALUES (?, ?)",
+        (other_id, tag_id),
+    )
+    db.commit()
+
+    response = admin_client.delete(f"/api/items/{target_id}/tags/{tag_id}")
+
+    assert response.status_code == 404
+    assert response.text == "Tag not found on item"
+    assert db.execute(
+        "SELECT 1 FROM item_tags WHERE item_id = ? AND tag_id = ?",
+        (other_id, tag_id),
+    ).fetchone() is not None
+    assert db.execute("SELECT 1 FROM tags WHERE id = ?", (tag_id,)).fetchone() is not None


### PR DESCRIPTION
## Summary
- return 404 when the target item no longer exists
- return 404 when the requested tag is not attached to the item
- garbage-collect orphan tags only after an association was actually removed
- preserve unrelated tag associations on stale or forged requests
- add focused regressions

## Testing
Rebuilt as one commit directly from upstream main from the previously full-CI-tested fork change.