### PR TITLE
Handle scan fetch failures truthfully

### DIFF
--- a/static/js/scan.js
+++ b/static/js/scan.js
@@ -46,9 +46,15 @@ function scanPage() {
 
         loadRecentScans(m) {
             fetch('/api/recent-scans?mode=' + encodeURIComponent(m))
-                .then(function(r) { return r.text(); })
+                .then(function(r) {
+                    if (!r.ok) throw new Error('HTTP ' + r.status);
+                    return r.text();
+                })
                 .then(function(html) {
                     document.getElementById('scan-results').innerHTML = html;
+                })
+                .catch(function() {
+                    showToast('Could not load recent scans', 'error');
                 });
         },
 
@@ -105,9 +111,18 @@ function scanPage() {
             var form = new FormData();
             form.set('location_id', this.location);
             form.set('scanned_ids', this.inventoryScannedIds.join(','));
-            var resp = await fetch('/api/inventory/missing', {method: 'POST', headers: {'X-CSRF-Token': window.csrfToken()}, body: form});
-            var html = await resp.text();
-            document.getElementById('inventory-missing').innerHTML = html;
+            try {
+                var resp = await fetch('/api/inventory/missing', {
+                    method: 'POST',
+                    headers: {'X-CSRF-Token': window.csrfToken()},
+                    body: form
+                });
+                if (!resp.ok) throw new Error('HTTP ' + resp.status);
+                var html = await resp.text();
+                document.getElementById('inventory-missing').innerHTML = html;
+            } catch (e) {
+                showToast('Could not check missing items', 'error');
+            }
         },
 
         async toggleCamera() {
@@ -218,6 +233,7 @@ function scanPage() {
             if (this.mode === 'lend') formData.set('borrower_id', this.borrowerId);
             try {
                 var resp = await fetch('/api/scan', { method: 'POST', headers: { 'X-CSRF-Token': window.csrfToken() }, body: formData });
+                if (!resp.ok) throw new Error('HTTP ' + resp.status);
                 var html = await resp.text();
 
                 // Insert result into the scan results list
@@ -252,7 +268,7 @@ function scanPage() {
                     }
                 }
             } catch (err) {
-                this.scanResult = { ok: false, warn: false, label: 'error', title: 'Network error', isbn: code };
+                this.scanResult = { ok: false, warn: false, label: 'error', title: 'Scan failed', isbn: code };
             }
             this.scanLoading = false;
         }

--- a/tests/test_scan_fetch_boundaries.py
+++ b/tests/test_scan_fetch_boundaries.py
@@ -1,0 +1,13 @@
+"""Offline guards for scan-page fetch error handling."""
+
+from pathlib import Path
+
+
+def test_scan_fetch_paths_reject_http_errors_before_consuming_bodies():
+    js = Path(__file__).resolve().parent.parent.joinpath("static/js/scan.js").read_text()
+
+    assert "if (!r.ok) throw new Error('HTTP ' + r.status);" in js
+    assert js.count("if (!resp.ok) throw new Error('HTTP ' + resp.status);") >= 2
+    assert "Could not load recent scans" in js
+    assert "Could not check missing items" in js
+    assert "title: 'Scan failed'" in js


### PR DESCRIPTION
## Summary
- reject non-2xx responses before consuming recent-scan HTML
- prevent Inventory Missing from rendering HTTP error bodies as successful content
- make camera scans treat HTTP failures as scan failures
- show concise user-facing error feedback
- add an offline regression for all three fetch boundaries

## Testing
Rebuilt as one commit directly from upstream main from the previously full-CI-tested fork change.