### PR TITLE
Harden CSV import boundaries

### DIFF
--- a/app/routers/items_csv.py
+++ b/app/routers/items_csv.py
@@ -15,6 +15,7 @@ from fastapi.responses import JSONResponse
 from starlette.responses import Response
 
 from app.auth import require_role
+from app.config import MEDIA_TYPES
 from app.database import get_db
 from app.routers import items_common
 from app.services import cover_queue
@@ -73,6 +74,13 @@ async def import_csv(request: Request, _=Depends(require_role("admin"))):
 
     form = await request.form()
     mode = form.get("mode", "skip")  # skip or update
+    if mode not in ("skip", "update"):
+        return {
+            "error": "Invalid import mode",
+            "imported": 0,
+            "skipped": 0,
+            "errors": [],
+        }
     to_read_wishlist = form.get("to_read_wishlist") in ("1", "true", "on")
     enrich_covers = form.get("enrich_covers") in ("1", "true", "on")
     csv_file = form.get("file")
@@ -125,8 +133,21 @@ async def import_csv(request: Request, _=Depends(require_role("admin"))):
                     errors.append(f"Row {i}: series_name too long (max {_CSV_MAX_TEXT} chars)")
                     continue
 
-                isbn_val = norm["isbn"]
+                raw_isbn = norm["isbn"]
+                if raw_isbn:
+                    isbn_pair = isbn_svc.canonical_isbn_pair(raw_isbn)
+                    if isbn_pair is None:
+                        errors.append(f"Row {i}: invalid ISBN")
+                        continue
+                else:
+                    isbn_pair = None
+                isbn_val = isbn_pair[0] if isbn_pair else None
+                isbn10_val = isbn_pair[1] if isbn_pair else None
+
                 media = norm["media_type"]
+                if media not in MEDIA_TYPES:
+                    errors.append(f"Row {i}: invalid media_type")
+                    continue
 
                 owned = norm["owned"]
                 if to_read_wishlist and norm["reading_status"] == "want_to_read":
@@ -149,8 +170,9 @@ async def import_csv(request: Request, _=Depends(require_role("admin"))):
                 if isbn_val:
                     file_key = ("isbn", isbn_val, media)
                     existing = db.execute(
-                        "SELECT id FROM items WHERE isbn = ? AND media_type = ?",
-                        (isbn_val, media),
+                        "SELECT id FROM items WHERE media_type = ? AND "
+                        "(isbn = ? OR (? IS NOT NULL AND isbn10 = ?))",
+                        (media, isbn_val, isbn10_val, isbn10_val),
                     ).fetchone()
                 else:
                     file_key = ("title", title.strip().lower(), authors_val.strip().lower(), media)
@@ -192,6 +214,7 @@ async def import_csv(request: Request, _=Depends(require_role("admin"))):
                     title=title,
                     authors=norm["authors"],
                     isbn=isbn_val,
+                    isbn10=isbn10_val,
                     media_type=media,
                     publisher=norm["publisher"],
                     publish_year=int(pub_year) if pub_year and str(pub_year).isdigit() else None,

--- a/tests/e2e/test_csv.py
+++ b/tests/e2e/test_csv.py
@@ -41,7 +41,7 @@ def test_csv_export(live_server, browser, setup_admin):
 def test_csv_import(live_server, authed_page):
     """Uploading a CSV file via the settings page imports items."""
     # Build a minimal CSV
-    csv_content = "title,media_type,isbn\nImported Book,book,9780000222333\n"
+    csv_content = "title,media_type,isbn\nImported Book,book,9780000222336\n"
 
     authed_page.goto(f"{live_server['url']}/settings")
     authed_page.wait_for_load_state("networkidle")
@@ -83,9 +83,9 @@ def test_goodreads_import_via_ui(live_server, authed_page):
         "Private Notes,Read Count,Owned Copies"
     )
     rows = [
-        '1,GR Read Book,Ann Author,"Author, Ann",,"=""""","=""9780900000011""",'
+        '1,GR Read Book,Ann Author,"Author, Ann",,"=""""","=""9780900000010""",'
         '5,4.2,Ace,Paperback,300,2005,1999,2023/08/15,2023/01/02,,,read,,,,1,0',
-        '2,GR Wishlist Book,Bob Writer,"Writer, Bob",,"=""""","=""9780900000028""",'
+        '2,GR Wishlist Book,Bob Writer,"Writer, Bob",,"=""""","=""9780900000027""",'
         '0,4.0,Bantam,Hardcover,500,1990,1989,,2023/01/02,,,to-read,,,,0,0',
     ]
     csv_content = header + "\n" + "\n".join(rows) + "\n"

--- a/tests/test_csv_import_boundaries.py
+++ b/tests/test_csv_import_boundaries.py
@@ -1,0 +1,75 @@
+"""Regression coverage for CSV import data boundaries."""
+
+import io
+
+from tests.conftest import _insert_item
+
+
+def _import_csv(client, content: str, mode: str = "skip"):
+    response = client.post(
+        "/api/import/csv",
+        files={"file": ("import.csv", io.BytesIO(content.encode()), "text/csv")},
+        data={"mode": mode},
+    )
+    assert response.status_code == 200
+    return response.json()
+
+
+def test_isbn10_import_matches_existing_isbn13(admin_client, db):
+    _insert_item(db, title="Dune", isbn="9780441172719", isbn10="0441172717")
+    db.commit()
+
+    result = _import_csv(
+        admin_client,
+        "title,authors,isbn,media_type\nDune,Frank Herbert,0441172717,book\n",
+    )
+
+    assert result["imported"] == 0
+    assert result["skipped"] == 1
+    assert db.execute("SELECT COUNT(*) FROM items").fetchone()[0] == 1
+
+
+def test_isbn10_import_persists_canonical_pair(admin_client, db):
+    result = _import_csv(
+        admin_client,
+        "title,authors,isbn,media_type\nDune,Frank Herbert,0441172717,book\n",
+    )
+
+    assert result["imported"] == 1
+    row = db.execute("SELECT isbn, isbn10 FROM items WHERE title = 'Dune'").fetchone()
+    assert row["isbn"] == "9780441172719"
+    assert row["isbn10"] == "0441172717"
+
+
+def test_bad_checksum_isbn_is_rejected_not_dropped(admin_client, db):
+    result = _import_csv(
+        admin_client,
+        "title,authors,isbn,media_type\nDune,Frank Herbert,9780441172718,book\n",
+    )
+
+    assert result["imported"] == 0
+    assert result["errors"] == ["Row 2: invalid ISBN"]
+    assert db.execute("SELECT COUNT(*) FROM items").fetchone()[0] == 0
+
+
+def test_invalid_import_mode_is_rejected(admin_client, db):
+    result = _import_csv(
+        admin_client,
+        "title,authors,isbn,media_type\nDune,Frank Herbert,9780441172719,book\n",
+        mode="overwrite",
+    )
+
+    assert result["error"] == "Invalid import mode"
+    assert result["imported"] == 0
+    assert db.execute("SELECT COUNT(*) FROM items").fetchone()[0] == 0
+
+
+def test_invalid_media_type_is_rejected(admin_client, db):
+    result = _import_csv(
+        admin_client,
+        "title,authors,isbn,media_type\nDune,Frank Herbert,,vhs\n",
+    )
+
+    assert result["imported"] == 0
+    assert result["errors"] == ["Row 2: invalid media_type"]
+    assert db.execute("SELECT COUNT(*) FROM items").fetchone()[0] == 0

--- a/tests/test_reading_imports.py
+++ b/tests/test_reading_imports.py
@@ -316,7 +316,7 @@ class TestStorygraphImport:
 
 class TestGenericStillWorks:
     def test_generic_format_reported(self, admin_client):
-        csv_content = "title,authors,isbn\nSome Book,Someone,9780000000111"
+        csv_content = "title,authors,isbn\nSome Book,Someone,9780000000118"
         data = _post_csv(admin_client, csv_content).json()
         assert data["format"] == "generic"
         assert data["imported"] == 1
@@ -555,15 +555,15 @@ class TestEnrichImportCoversQueues:
         monkeypatch.delenv("SHELF_DISABLE_COVER_ENRICH", raising=False)
         csv_content = (
             "title,authors,isbn,media_type\n"
-            "Some Book,Someone,9780000000111,book\n"
-            "Some DVD,,9780000000222,dvd"
+            "Some Book,Someone,9780000000118,book\n"
+            "Some DVD,,9780000000224,dvd"
         )
         with patch("app.routers.items_common._enrich_import_covers", new=AsyncMock()) as enrich:
             data = _post_csv(admin_client, csv_content, enrich_covers="1").json()
 
         assert data["covers_queued"] == 1
         book_id = db.execute(
-            "SELECT id FROM items WHERE isbn = '9780000000111'"
+            "SELECT id FROM items WHERE isbn = '9780000000118'"
         ).fetchone()["id"]
         enrich.assert_called_once_with([book_id])
 

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -126,7 +126,7 @@ class TestGraphQLIntCoercion:
         """Non-integer book_id must raise ValueError before any query is built."""
         from app.services.hardcover import create_user_book
         with pytest.raises((ValueError, TypeError)):
-            await create_user_book("token", "malicious}")
+            await create_user_book("token", "malicious")
 
     @pytest.mark.anyio
     async def test_create_user_book_rejects_non_int_status_id(self):
@@ -398,7 +398,7 @@ class TestCSVFieldLengthCaps:
             "authors": "Author Name",
             "publisher": "Publisher",
             "series_name": "Series",
-            "isbn": "9780000001234",
+            "isbn": "9780000001238",
             "media_type": "book",
         }
         fields.update(overrides)
@@ -455,7 +455,7 @@ class TestCSVFieldLengthCaps:
 
     def test_at_limit_fields_import_successfully(self, admin_client):
         """Exactly 1000 characters should be accepted."""
-        csv_content = self._make_csv(authors="A" * 1000, isbn="9780000001235")
+        csv_content = self._make_csv(authors="A" * 1000, isbn="9780000001245")
         resp = admin_client.post(
             "/api/import/csv",
             files={"file": ("test.csv", io.BytesIO(csv_content.encode()), "text/csv")},


### PR DESCRIPTION
## Summary
- canonicalise imported ISBNs and persist matching ISBN-13/ISBN-10 pairs
- deduplicate ISBN-10 imports against canonical ISBN-13 rows
- reject bad-checksum ISBNs instead of silently importing ISBN-less rows
- reject unsupported import modes and media types before persistence
- correct affected fixtures to checksum-valid ISBNs
- add focused regressions for all boundary cases

## Testing
Rebuilt as one commit directly from upstream main from the previously full-CI-tested fork change.