### PR TITLE
Harden authentication boundaries

### DIFF
--- a/app/routers/auth_routes.py
+++ b/app/routers/auth_routes.py
@@ -1,6 +1,6 @@
 import logging
+import sqlite3
 
-import bcrypt
 from fastapi import APIRouter, Form, Request, Depends
 from fastapi.responses import RedirectResponse, HTMLResponse
 
@@ -13,6 +13,12 @@ from app.config import get_client_ip
 from app.database import get_db
 
 logger = logging.getLogger(__name__)
+
+# Unknown usernames must do the same one bcrypt verification as known usernames
+# without generating a fresh salt/hash on every request. The hash is created
+# once at process start; the fixed plaintext is deliberately not a valid
+# account credential and only exists to equalise the password-check work factor.
+_DUMMY_PASSWORD_HASH = hash_password("dummy")
 
 router = APIRouter()
 
@@ -39,8 +45,8 @@ async def login(request: Request, username: str = Form(...), password: str = For
         ).fetchone()
 
     if not user:
-        # Run a dummy bcrypt check to prevent username enumeration via timing
-        bcrypt.checkpw(b"dummy", bcrypt.hashpw(b"dummy", bcrypt.gensalt()))
+        # One bcrypt verification on both known and unknown username paths.
+        verify_password("dummy", _DUMMY_PASSWORD_HASH)
         logger.warning("Failed login attempt for username=%s from %s", username, get_client_ip(request))
         return templates.TemplateResponse(
             request, "login.html",
@@ -113,6 +119,12 @@ async def setup(
         )
 
     with get_db() as db:
+        # The initial get_user_count() is only a fast path. Serialize the
+        # authoritative "still no users?" decision with the insert so two
+        # concurrent first-run requests cannot both create an administrator.
+        db.execute("BEGIN IMMEDIATE")
+        if db.execute("SELECT 1 FROM users LIMIT 1").fetchone():
+            return RedirectResponse(url="/login", status_code=303)
         db.execute(
             "INSERT INTO users (username, password, display_name, role) VALUES (?, ?, ?, 'admin')",
             (username, hash_password(password), display_name),
@@ -162,7 +174,7 @@ async def create_user(
                 "INSERT INTO users (username, password, display_name, role) VALUES (?, ?, ?, ?)",
                 (username, hash_password(password), display_name, role),
             )
-    except Exception:
+    except sqlite3.IntegrityError:
         logger.warning("Failed to create user '%s': username already exists", username)
         return {"ok": False, "message": "Username already exists"}
 

--- a/tests/test_auth_boundaries.py
+++ b/tests/test_auth_boundaries.py
@@ -1,0 +1,110 @@
+"""Regression coverage for authentication/setup mutation boundaries."""
+
+import sqlite3
+from contextlib import contextmanager
+
+import pytest
+
+
+def test_unknown_login_uses_precomputed_dummy_hash(client, admin_user, monkeypatch):
+    import app.routers.auth_routes as auth_routes
+
+    calls = []
+
+    def fake_verify(password, hashed):
+        calls.append((password, hashed))
+        return False
+
+    def unexpected_hash(_password):
+        raise AssertionError("unknown-user login generated a fresh bcrypt hash")
+
+    monkeypatch.setattr(auth_routes, "verify_password", fake_verify)
+    monkeypatch.setattr(auth_routes, "hash_password", unexpected_hash)
+
+    response = client.post(
+        "/login",
+        data={"username": "does-not-exist", "password": "wrong-password"},
+    )
+
+    assert response.status_code == 401
+    assert calls == [("dummy", auth_routes._DUMMY_PASSWORD_HASH)]
+
+
+def test_setup_zero_user_guard_runs_under_write_lock(client, monkeypatch):
+    import app.config
+    import app.routers.auth_routes as auth_routes
+
+    real_get_db = auth_routes.get_db
+    probe_results = []
+
+    class LockProbingConnection:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+        def execute(self, sql, *args, **kwargs):
+            result = self._conn.execute(sql, *args, **kwargs)
+            if sql == "SELECT 1 FROM users LIMIT 1":
+                rival = sqlite3.connect(str(app.config.DATABASE_PATH), timeout=0)
+                try:
+                    rival.execute("BEGIN IMMEDIATE")
+                    probe_results.append("acquired")
+                    rival.rollback()
+                except sqlite3.OperationalError as exc:
+                    probe_results.append(f"locked: {exc}")
+                finally:
+                    rival.close()
+            return result
+
+    @contextmanager
+    def probing_get_db():
+        with real_get_db() as conn:
+            yield LockProbingConnection(conn)
+
+    monkeypatch.setattr(auth_routes, "get_db", probing_get_db)
+
+    response = client.post(
+        "/setup",
+        data={
+            "username": "admin",
+            "display_name": "Admin",
+            "password": "password123",
+            "password_confirm": "password123",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert probe_results, "the in-transaction zero-user guard never ran"
+    assert probe_results[0].startswith("locked"), (
+        "a rival setup writer acquired SQLite's write lock while the "
+        f"authoritative guard was being read: {probe_results[0]!r}"
+    )
+
+
+def test_create_user_does_not_mask_unexpected_database_failure(
+    admin_client, monkeypatch
+):
+    import app.routers.auth_routes as auth_routes
+
+    class BrokenConnection:
+        def execute(self, _sql, *_args, **_kwargs):
+            raise RuntimeError("database unavailable")
+
+    @contextmanager
+    def broken_get_db():
+        yield BrokenConnection()
+
+    monkeypatch.setattr(auth_routes, "get_db", broken_get_db)
+
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        admin_client.post(
+            "/api/users",
+            data={
+                "username": "new-user",
+                "password": "password123",
+                "role": "viewer",
+            },
+        )


### PR DESCRIPTION
## Summary
- use constant password-verification work for unknown usernames without generating a fresh bcrypt hash per request
- serialize first-admin setup and re-check the zero-user invariant inside the write transaction
- handle duplicate-user integrity errors without masking unrelated database failures
- add focused authentication boundary regressions

## Testing
Rebuilt as one clean commit from upstream main from the previously full-CI-tested fork change.