### PR TITLE
Make checkout request boundaries truthful

### DIFF
--- a/app/routers/checkouts.py
+++ b/app/routers/checkouts.py
@@ -1,7 +1,7 @@
 from datetime import date, timedelta
 
 from fastapi import APIRouter, Depends, Form, Request
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 
 from app.auth import require_role
 from app.database import get_db, get_setting
@@ -98,7 +98,15 @@ async def checkout_item(
 ):
     """Check out an item to a borrower."""
     templates = request.app.state.templates
-    due = (date.today() + timedelta(days=due_days)).isoformat() if due_days > 0 else None
+    if due_days > 0:
+        try:
+            due = (date.today() + timedelta(days=due_days)).isoformat()
+        except OverflowError:
+            return JSONResponse(
+                {"ok": False, "message": "Due date is out of range"}, status_code=400
+            )
+    else:
+        due = None
 
     with get_db() as db:
         # Check not already checked out
@@ -118,14 +126,28 @@ async def checkout_item(
 
 @router.post("/checkouts/{checkout_id}/checkin")
 async def checkin_item(checkout_id: int, _=Depends(require_role("editor"))):
-    """Check in an item (return it)."""
+    """Check in an active item loan exactly once."""
     with get_db() as db:
-        checkout = db.execute("SELECT item_id FROM checkouts WHERE id = ?", (checkout_id,)).fetchone()
+        checkout = db.execute(
+            "SELECT item_id, checked_in FROM checkouts WHERE id = ?", (checkout_id,)
+        ).fetchone()
         if not checkout:
-            return {"ok": False, "message": "Checkout not found"}
-        db.execute(
-            "UPDATE checkouts SET checked_in = datetime('now') WHERE id = ?", (checkout_id,)
+            return JSONResponse(
+                {"ok": False, "message": "Checkout not found"}, status_code=404
+            )
+        if checkout["checked_in"] is not None:
+            return JSONResponse(
+                {"ok": False, "message": "Checkout already checked in"}, status_code=409
+            )
+        cursor = db.execute(
+            "UPDATE checkouts SET checked_in = datetime('now') "
+            "WHERE id = ? AND checked_in IS NULL",
+            (checkout_id,),
         )
+        if cursor.rowcount != 1:
+            return JSONResponse(
+                {"ok": False, "message": "Checkout already checked in"}, status_code=409
+            )
     return RedirectResponse(url=f"/item/{checkout['item_id']}", status_code=303)
 
 

--- a/tests/test_checkout_request_boundaries.py
+++ b/tests/test_checkout_request_boundaries.py
@@ -1,0 +1,28 @@
+"""Regression coverage for checkout/check-in request boundaries."""
+
+from tests.conftest import _insert_borrower, _insert_item
+
+
+def test_checkout_rejects_due_date_overflow(admin_client):
+    resp = admin_client.post(
+        "/api/items/999999/checkout",
+        data={"borrower_id": "999999", "due_days": str(10**100)},
+    )
+    assert resp.status_code == 400
+    assert resp.json() == {"ok": False, "message": "Due date is out of range"}
+
+
+def test_checkin_rejects_already_returned_checkout(admin_client, db):
+    item_id = _insert_item(db, title="Already Returned", isbn="9780000000200")
+    borrower_id = _insert_borrower(db, "Returned Borrower")
+    cursor = db.execute(
+        "INSERT INTO checkouts (item_id, borrower_id, checked_out, checked_in) "
+        "VALUES (?, ?, datetime('now', '-1 day'), datetime('now'))",
+        (item_id, borrower_id),
+    )
+    checkout_id = cursor.lastrowid
+    db.commit()
+
+    resp = admin_client.post(f"/api/checkouts/{checkout_id}/checkin")
+    assert resp.status_code == 409
+    assert resp.json() == {"ok": False, "message": "Checkout already checked in"}


### PR DESCRIPTION
## Summary
- reject due-date values that overflow the supported date range instead of raising a server error
- return 404 when checking in a checkout that does not exist
- return 409 when a checkout has already been returned
- make the check-in update conditional so a loan can only be closed once
- add focused regressions

## Testing
Rebuilt directly from upstream main as an independent checkout-only change.