### PR TITLE
Harden Audiobookshelf sync correctness and diagnostics

### DIFF
--- a/app/services/audiobookshelf.py
+++ b/app/services/audiobookshelf.py
@@ -24,12 +24,22 @@ def get_excluded_libraries() -> set[str]:
         return set()
 
 
+def _normalise_publish_year(value):
+    """Match SQLite's usual INTEGER coercion so an unchanged year stays unchanged."""
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return value
+
+
 async def sync(abs_url: str, abs_token: str, on_progress=None) -> dict:
     """Sync items from Audiobookshelf. Returns summary stats.
 
     on_progress: optional async callback(current, total, title, status) for progress updates.
     """
-    stats = {"added": 0, "updated": 0, "skipped": 0, "errors": 0}
+    stats = {"added": 0, "updated": 0, "unchanged": 0, "skipped": 0, "errors": 0}
 
     headers = {"Authorization": f"Bearer {abs_token}"}
     excluded = get_excluded_libraries()
@@ -45,15 +55,24 @@ async def sync(abs_url: str, abs_token: str, on_progress=None) -> dict:
             if lib.get("id") not in excluded
         ]
 
-        # First pass: fetch all library items to get total count
+        # First pass: fetch all library items to get total count. A single
+        # large/slow library should not prevent healthy libraries from syncing.
         lib_items = []
         for lib in libraries:
             lib_id = lib["id"]
-            resp = await client.get(
-                f"{abs_url}/api/libraries/{lib_id}/items",
-                headers=headers,
-                params={"limit": 10000},
-            )
+            try:
+                resp = await client.get(
+                    f"{abs_url}/api/libraries/{lib_id}/items",
+                    headers=headers,
+                    params={"limit": 10000},
+                )
+            except httpx.TimeoutException:
+                logger.warning(
+                    "Timed out fetching Audiobookshelf library %s; skipping it for this sync",
+                    lib_id,
+                )
+                stats["errors"] += 1
+                continue
             if resp.status_code != 200:
                 stats["errors"] += 1
                 continue
@@ -101,7 +120,21 @@ async def sync(abs_url: str, abs_token: str, on_progress=None) -> dict:
                 if not title:
                     stats["skipped"] += 1
                     if on_progress:
-                        await on_progress(current, total, "(untitled)", "skipped")
+                        item_label = abs_id or "unknown item"
+                        await on_progress(
+                            current, total,
+                            f"Missing title — Audiobookshelf item {item_label}",
+                            "skipped",
+                        )
+                    continue
+                if not abs_id:
+                    stats["skipped"] += 1
+                    if on_progress:
+                        await on_progress(
+                            current, total,
+                            f"Missing Audiobookshelf item ID — {title}",
+                            "skipped",
+                        )
                     continue
 
                 authors = metadata.get("authorName") or metadata.get("author")
@@ -109,7 +142,7 @@ async def sync(abs_url: str, abs_token: str, on_progress=None) -> dict:
                 isbn = metadata.get("isbn") or metadata.get("asin")
                 series_name = metadata.get("seriesName")
                 publisher = metadata.get("publisher")
-                pub_year = metadata.get("publishedYear")
+                pub_year = _normalise_publish_year(metadata.get("publishedYear"))
                 description = metadata.get("description")
 
                 duration_secs = media.get("duration")
@@ -117,25 +150,101 @@ async def sync(abs_url: str, abs_token: str, on_progress=None) -> dict:
 
                 with get_db() as db:
                     existing = db.execute(
-                        "SELECT id FROM items WHERE abs_id = ?", (abs_id,)
+                        """SELECT id, title, authors, narrator, isbn, series_name,
+                                  publisher, publish_year, description, duration_mins,
+                                  media_type, abs_id, abs_library_id, cover_path
+                           FROM items WHERE abs_id = ?""",
+                        (abs_id,),
                     ).fetchone()
 
+                    # Shelf permits the same ISBN across formats, but not twice
+                    # within one media type. ABS IDs alone are therefore not
+                    # enough to decide whether an insert is safe: a manually
+                    # catalogued audiobook may already occupy the ISBN slot,
+                    # or ABS itself may expose duplicate records for it.
+                    isbn_match = None
+                    if isbn:
+                        if existing:
+                            isbn_match = db.execute(
+                                """SELECT id, abs_id FROM items
+                                   WHERE isbn = ? AND media_type = ? AND id != ?
+                                   ORDER BY id LIMIT 1""",
+                                (isbn, media_type, existing["id"]),
+                            ).fetchone()
+                        else:
+                            isbn_match = db.execute(
+                                """SELECT id, abs_id FROM items
+                                   WHERE isbn = ? AND media_type = ?
+                                   ORDER BY id LIMIT 1""",
+                                (isbn, media_type),
+                            ).fetchone()
+
+                    if isbn_match:
+                        if existing or isbn_match["abs_id"]:
+                            logger.warning(
+                                "Skipping ABS item %s (%s): ISBN %s already belongs "
+                                "to Shelf item %s for media type %s",
+                                abs_id, title, isbn, isbn_match["id"], media_type,
+                            )
+                            stats["skipped"] += 1
+                            if on_progress:
+                                await on_progress(
+                                    current, total,
+                                    f"ISBN conflict with Shelf item {isbn_match['id']} — {title} ({isbn})",
+                                    "skipped",
+                                )
+                            continue
+
+                        # Adopt an existing manually-added same-format item
+                        # instead of attempting a duplicate insert. From this
+                        # point on it follows the normal ABS update path.
+                        existing = db.execute(
+                            """SELECT id, title, authors, narrator, isbn, series_name,
+                                      publisher, publish_year, description, duration_mins,
+                                      media_type, abs_id, abs_library_id, cover_path
+                               FROM items WHERE id = ?""",
+                            (isbn_match["id"],),
+                        ).fetchone()
+
                     if existing:
-                        db.execute(
-                            """UPDATE items SET title=?, authors=?, narrator=?,
-                               isbn=?, series_name=?, publisher=?, publish_year=?,
-                               description=?, duration_mins=?, media_type=?,
-                               abs_library_id=?,
-                               updated_at=datetime('now')
-                               WHERE abs_id=?""",
-                            (title, authors, narrator, isbn, series_name,
-                             publisher, pub_year, description, duration_mins,
-                             media_type, lib_id, abs_id),
-                        )
-                        stats["updated"] += 1
+                        desired = {
+                            "title": title,
+                            "authors": authors,
+                            "narrator": narrator,
+                            "isbn": isbn,
+                            "series_name": series_name,
+                            "publisher": publisher,
+                            "publish_year": pub_year,
+                            "description": description,
+                            "duration_mins": duration_mins,
+                            "media_type": media_type,
+                            "abs_id": abs_id,
+                            "abs_library_id": lib_id,
+                        }
+                        changed = any(existing[key] != value for key, value in desired.items())
+
+                        if changed:
+                            db.execute(
+                                """UPDATE items SET title=?, authors=?, narrator=?,
+                                   isbn=?, series_name=?, publisher=?, publish_year=?,
+                                   description=?, duration_mins=?, media_type=?,
+                                   abs_id=?, abs_library_id=?,
+                                   updated_at=datetime('now')
+                                   WHERE id=?""",
+                                (title, authors, narrator, isbn, series_name,
+                                 publisher, pub_year, description, duration_mins,
+                                 media_type, abs_id, lib_id, existing["id"]),
+                            )
+                            stats["updated"] += 1
+                            status = "updated"
+                        else:
+                            stats["unchanged"] += 1
+                            status = "unchanged"
+
                         item_id = existing["id"]
+                        fetch_cover = changed or not existing["cover_path"]
                         if on_progress:
-                            await on_progress(current, total, title, "updated")
+                            await on_progress(current, total, title, status)
                     else:
                         item_id = insert_item(
                             db,
@@ -154,10 +263,15 @@ async def sync(abs_url: str, abs_token: str, on_progress=None) -> dict:
                             source="audiobookshelf",
                         )
                         stats["added"] += 1
+                        fetch_cover = True
                         if on_progress:
                             await on_progress(current, total, title, "added")
 
-                # Download cover from ABS
+                # Download covers for new/changed items, or fill a missing
+                # cover on an otherwise unchanged item. Stable items with a
+                # cover no longer re-download the same image on every sync.
+                if not fetch_cover:
+                    continue
                 try:
                     cover_resp = await client.get(
                         f"{abs_url}/api/items/{abs_id}/cover",

--- a/app/templates/fragments/settings/integrations.html
+++ b/app/templates/fragments/settings/integrations.html
@@ -108,6 +108,7 @@
                     <p class="text-shelf-success">
                         Added: <span x-text="result.added"></span>,
                         Updated: <span x-text="result.updated"></span>,
+                        Unchanged: <span x-text="result.unchanged"></span>,
                         Skipped: <span x-text="result.skipped"></span>
                     </p>
                 </template>

--- a/tests/test_abs_sync_isbn_collisions.py
+++ b/tests/test_abs_sync_isbn_collisions.py
@@ -1,0 +1,115 @@
+"""Audiobookshelf sync must respect Shelf's ISBN/media-type uniqueness rule."""
+import asyncio
+
+import httpx
+import respx
+
+from app.services.audiobookshelf import sync
+from tests.conftest import _insert_item
+
+ABS = "http://abs.example:13378"
+ISBN = "9780000000998"
+
+
+def _libraries_response():
+    return httpx.Response(200, json={"libraries": [
+        {"id": "lib_audio", "name": "Audiobooks", "mediaType": "book"},
+    ]})
+
+
+def _items_response(*items):
+    return httpx.Response(200, json={"results": [
+        {
+            "id": abs_id,
+            "media": {
+                "metadata": {"title": title, "isbn": isbn},
+                "numAudioFiles": 1,
+                "duration": 3600,
+            },
+        }
+        for abs_id, title, isbn in items
+    ]})
+
+
+def _mock_library(*items):
+    respx.get(f"{ABS}/api/libraries").mock(return_value=_libraries_response())
+    respx.get(f"{ABS}/api/libraries/lib_audio/items").mock(
+        return_value=_items_response(*items)
+    )
+
+
+@respx.mock
+def test_sync_adopts_existing_same_format_isbn_without_abs_id(db):
+    existing_id = _insert_item(
+        db,
+        title="Manual Audiobook",
+        isbn=ISBN,
+        media_type="audiobook",
+    )
+    db.execute("COMMIT")
+
+    _mock_library(("li_1", "Synced Audiobook", ISBN))
+    respx.get(f"{ABS}/api/items/li_1/cover").mock(return_value=httpx.Response(404))
+
+    stats = asyncio.run(sync(ABS, "token"))
+
+    assert stats == {
+        "added": 0, "updated": 1, "unchanged": 0, "skipped": 0, "errors": 0
+    }
+    rows = db.execute(
+        "SELECT id, title, isbn, media_type, abs_id, abs_library_id FROM items"
+    ).fetchall()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["id"] == existing_id
+    assert row["title"] == "Synced Audiobook"
+    assert row["isbn"] == ISBN
+    assert row["media_type"] == "audiobook"
+    assert row["abs_id"] == "li_1"
+    assert row["abs_library_id"] == "lib_audio"
+
+    # Running the same sync again is a true no-op for item metadata: it is
+    # reported as unchanged and does not rewrite updated_at.
+    db.execute("UPDATE items SET updated_at = '2000-01-01 00:00:00' WHERE id = ?", (existing_id,))
+    db.execute("COMMIT")
+
+    second = asyncio.run(sync(ABS, "token"))
+
+    assert second == {
+        "added": 0, "updated": 0, "unchanged": 1, "skipped": 0, "errors": 0
+    }
+    updated_at = db.execute(
+        "SELECT updated_at FROM items WHERE id = ?", (existing_id,)
+    ).fetchone()["updated_at"]
+    assert updated_at == "2000-01-01 00:00:00"
+
+
+@respx.mock
+def test_sync_skips_second_abs_record_with_same_format_isbn(db):
+    _mock_library(
+        ("li_1", "First ABS Copy", ISBN),
+        ("li_2", "Duplicate ABS Copy", ISBN),
+    )
+    # The duplicate must be rejected before cover work, so only li_1 is mocked.
+    respx.get(f"{ABS}/api/items/li_1/cover").mock(return_value=httpx.Response(404))
+    progress = []
+
+    async def on_progress(current, total, title, status):
+        progress.append((current, total, title, status))
+
+    stats = asyncio.run(sync(ABS, "token", on_progress=on_progress))
+
+    assert stats == {
+        "added": 1, "updated": 0, "unchanged": 0, "skipped": 1, "errors": 0
+    }
+    rows = db.execute(
+        "SELECT title, isbn, media_type, abs_id FROM items ORDER BY id"
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["title"] == "First ABS Copy"
+    assert rows[0]["isbn"] == ISBN
+    assert rows[0]["media_type"] == "audiobook"
+    assert rows[0]["abs_id"] == "li_1"
+    assert progress[-1][3] == "skipped"
+    assert progress[-1][2].startswith("ISBN conflict with Shelf item ")
+    assert "Duplicate ABS Copy" in progress[-1][2]

--- a/tests/test_abs_sync_timeouts.py
+++ b/tests/test_abs_sync_timeouts.py
@@ -1,0 +1,47 @@
+"""Audiobookshelf sync should not lose healthy libraries to one slow library."""
+import asyncio
+
+import httpx
+import respx
+
+from app.services.audiobookshelf import sync
+
+ABS = "http://abs.example:13378"
+
+
+def _libraries_response():
+    return httpx.Response(200, json={"libraries": [
+        {"id": "lib_slow", "name": "Slow Audiobooks", "mediaType": "book"},
+        {"id": "lib_good", "name": "Audiobooks", "mediaType": "book"},
+    ]})
+
+
+def _items_response(abs_id, title):
+    return httpx.Response(200, json={"results": [{
+        "id": abs_id,
+        "media": {
+            "metadata": {"title": title},
+            "numAudioFiles": 1,
+            "duration": 3600,
+        },
+    }]})
+
+
+@respx.mock
+def test_sync_skips_timed_out_library_and_continues(db):
+    respx.get(f"{ABS}/api/libraries").mock(return_value=_libraries_response())
+    respx.get(f"{ABS}/api/libraries/lib_slow/items").mock(
+        side_effect=httpx.ReadTimeout("slow library")
+    )
+    respx.get(f"{ABS}/api/libraries/lib_good/items").mock(
+        return_value=_items_response("li_good", "Healthy Book")
+    )
+    respx.get(f"{ABS}/api/items/li_good/cover").mock(return_value=httpx.Response(404))
+
+    stats = asyncio.run(sync(ABS, "token"))
+
+    assert stats == {
+        "added": 1, "updated": 0, "unchanged": 0, "skipped": 0, "errors": 1
+    }
+    rows = db.execute("SELECT title, abs_id FROM items").fetchall()
+    assert [(r["title"], r["abs_id"]) for r in rows] == [("Healthy Book", "li_good")]


### PR DESCRIPTION
## Summary
- adopt an existing manually-catalogued same-format ISBN instead of attempting a duplicate insert
- skip duplicate Audiobookshelf same-format ISBN records without aborting the sync
- allow healthy libraries to continue when one Audiobookshelf library times out
- distinguish real updates from unchanged items and avoid rewriting unchanged metadata
- avoid re-downloading covers for unchanged items that already have one
- report useful reasons for skipped items and show the Unchanged count in Settings
- add regressions for ISBN collisions, repeat-sync idempotency and library timeouts

## Testing
This combines three production-tested Audiobookshelf fixes from the fork into one coherent upstream change. The branch is one commit directly from upstream main.