### PR TITLE
Fix CSP-safe bulk and shortcut interactions

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -107,6 +107,14 @@ document.body.addEventListener('showToast', function(e) {
 
 // --- Keyboard shortcuts ---
 document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+        var shortcutModal = document.getElementById('shortcut-modal');
+        if (shortcutModal && !shortcutModal.classList.contains('hidden')) {
+            shortcutModal.classList.add('hidden');
+            return;
+        }
+    }
+
     var tag = document.activeElement.tagName;
     if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
     if (e.key === '/' ) { e.preventDefault(); var q = document.querySelector('[name="q"]'); if (q) q.focus(); }
@@ -114,6 +122,35 @@ document.addEventListener('keydown', function(e) {
     else if (e.key === 'b') { window.location.href = '/browse'; }
     else if (e.key === '?') { document.getElementById('shortcut-modal').classList.toggle('hidden'); }
 });
+
+// The visible shortcut-help controls used inline onclick handlers. Shelf's
+// script-src 'self' CSP refuses those handlers, so the button and both close
+// surfaces looked clickable but did nothing. Bind the same behaviour from this
+// external script instead. Remove the inert inline attributes before a user can
+// click them so browsers do not report a CSP violation for the dead handler.
+(function() {
+    var modal = document.getElementById('shortcut-modal');
+    var trigger = document.querySelector('[title="Keyboard shortcuts (?)"]');
+    if (!modal || !trigger) return;
+
+    trigger.removeAttribute('onclick');
+    trigger.addEventListener('click', function() {
+        modal.classList.toggle('hidden');
+    });
+
+    modal.removeAttribute('onclick');
+    modal.addEventListener('click', function(e) {
+        if (e.target === modal) modal.classList.add('hidden');
+    });
+
+    var close = modal.querySelector('button[onclick]');
+    if (close) {
+        close.removeAttribute('onclick');
+        close.addEventListener('click', function() {
+            modal.classList.add('hidden');
+        });
+    }
+})();
 
 // --- Search-result form sync ---
 // Replaces the inline scripts formerly embedded in the book/dvd/game

--- a/static/js/browse.js
+++ b/static/js/browse.js
@@ -423,6 +423,13 @@ function browsePage() {
             this.selectedIds = [];
         },
 
+        // Alpine's CSP evaluator has no access to browser globals, so the
+        // template's bare parseInt(...) call must resolve on component scope.
+        // Keep the conversion here rather than weakening script-src.
+        parseInt(value) {
+            return Number.parseInt(value, 10);
+        },
+
         async bulkUpdate(updates) {
             if (!this.selectedIds.length) return;
             try {

--- a/tests/e2e/test_bulk_actions.py
+++ b/tests/e2e/test_bulk_actions.py
@@ -1,0 +1,88 @@
+"""E2E coverage for user-facing controls that previously had no browser test.
+
+These tests drive the actual Alpine/HTMX/CSP UI rather than calling API
+endpoints directly.  That distinction is important: an endpoint can be correct
+while a client-side expression prevents the button from ever sending a request.
+"""
+import sqlite3
+
+import pytest
+from playwright.sync_api import expect
+
+from tests.e2e.conftest import insert_item
+
+pytestmark = pytest.mark.e2e
+
+
+def _insert_location(data_dir, name: str) -> int:
+    conn = sqlite3.connect(str(data_dir / "shelf.db"))
+    try:
+        cur = conn.execute("INSERT INTO locations (name) VALUES (?)", (name,))
+        conn.commit()
+        return cur.lastrowid
+    finally:
+        conn.close()
+
+
+def _location_id(data_dir, item_id: int):
+    conn = sqlite3.connect(str(data_dir / "shelf.db"))
+    try:
+        row = conn.execute("SELECT location_id FROM items WHERE id = ?", (item_id,)).fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+def test_bulk_move_apply_moves_selected_list_item(live_server, authed_page):
+    """Selecting a list row, choosing a location and pressing Apply must move it.
+
+    This is deliberately a browser test.  The bulk-update API already has unit
+    coverage, but that did not catch a dead Alpine click expression in the UI.
+    """
+    location_id = _insert_location(live_server["data_dir"], "Bulk Move Target")
+    item_id = insert_item(
+        live_server["data_dir"],
+        title="Bulk Move Browser Probe",
+        isbn="9780000999401",
+    )
+
+    authed_page.goto(f"{live_server['url']}/browse")
+    authed_page.wait_for_load_state("networkidle")
+    authed_page.locator("[data-testid='view-list']").click()
+    expect(authed_page.locator(f"tr[data-item-id='{item_id}']")).to_be_visible()
+
+    authed_page.get_by_role("button", name="Select", exact=True).click()
+    authed_page.locator(f"tr[data-item-id='{item_id}']").click()
+    expect(authed_page.get_by_text("1 selected", exact=True)).to_be_visible()
+
+    authed_page.locator('select[x-model="bulkLocationVal"]').select_option(str(location_id))
+    apply_button = authed_page.get_by_role("button", name="Apply", exact=True).first
+    expect(apply_button).to_be_visible()
+    apply_button.click()
+
+    # A successful bulk update reloads Browse.  Wait for that reload before
+    # checking the database so this test cannot race the POST request.
+    authed_page.wait_for_load_state("networkidle")
+    assert _location_id(live_server["data_dir"], item_id) == location_id
+
+
+def test_shortcut_help_button_opens_and_modal_controls_close(live_server, authed_page):
+    """The visible ? button and modal close surfaces must work under strict CSP."""
+    authed_page.goto(f"{live_server['url']}/browse")
+    authed_page.wait_for_load_state("networkidle")
+
+    modal = authed_page.locator("#shortcut-modal")
+    expect(modal).to_be_hidden()
+
+    authed_page.get_by_title("Keyboard shortcuts (?)").click()
+    expect(modal).to_be_visible()
+
+    # The modal header has a single close button.
+    modal.locator("button").first.click()
+    expect(modal).to_be_hidden()
+
+    # Reopen and verify clicking the backdrop closes it too.
+    authed_page.get_by_title("Keyboard shortcuts (?)").click()
+    expect(modal).to_be_visible()
+    modal.click(position={"x": 5, "y": 5})
+    expect(modal).to_be_hidden()

--- a/tests/e2e/test_csp.py
+++ b/tests/e2e/test_csp.py
@@ -6,6 +6,7 @@ both "policy too loose" regressions (inline script sneaks in) and "policy too
 strict" ones (a required asset gets blocked and the page silently degrades).
 """
 import pytest
+from playwright.sync_api import expect
 
 from tests.e2e.conftest import assert_page_clean, attach_page_guard, insert_item
 
@@ -68,3 +69,39 @@ def test_js_stack_boots_under_csp(live_server, browser, setup_admin):
     assert page.evaluate("typeof window.browsePage") == "function"
     assert_page_clean(page)
     ctx.close()
+
+
+def test_shortcut_help_interacts_without_inline_script_violation(
+    live_server, browser, setup_admin
+):
+    """The keyboard-help button must actually work under Shelf's no-inline CSP."""
+    ctx = browser.new_context()
+    try:
+        page = attach_page_guard(ctx.new_page())
+        page.add_init_script(_VIOLATION_PROBE)
+        page.goto(f"{live_server['url']}/login")
+        page.fill("input[name=username]", setup_admin["username"])
+        page.fill("input[name=password]", setup_admin["password"])
+        page.click("button[type=submit]")
+        page.wait_for_url(f"{live_server['url']}/browse", timeout=10_000)
+
+        trigger = page.locator('button[title="Keyboard shortcuts (?)"]')
+        modal = page.locator("#shortcut-modal")
+        expect(modal).to_be_hidden()
+
+        trigger.click()
+        expect(modal).to_be_visible()
+        expect(modal).to_contain_text("Keyboard Shortcuts")
+        assert page.evaluate("window.__cspViolations") == []
+
+        modal.locator("button").click()
+        expect(modal).to_be_hidden()
+
+        trigger.click()
+        expect(modal).to_be_visible()
+        page.keyboard.press("Escape")
+        expect(modal).to_be_hidden()
+        assert page.evaluate("window.__cspViolations") == []
+        assert_page_clean(page)
+    finally:
+        ctx.close()


### PR DESCRIPTION
## Summary
- make Browse bulk-location Apply work under Alpine's CSP evaluator without weakening the CSP
- replace inert inline shortcut-modal handlers with external script listeners
- allow Escape to close the shortcut-help modal
- add real browser coverage for bulk move and shortcut controls
- assert the shortcut journey produces no CSP violations

## Testing
Combines the two related CSP interaction fixes from the fork. Exact upstream diff: app.js +37, browse.js +8/-1, one browser test file and the CSP smoke extension.