### PR TITLE
Reject stale Photo Intake locations

### DIFF
--- a/app/routers/intake.py
+++ b/app/routers/intake.py
@@ -18,12 +18,14 @@ from app.services import authors as authors_svc
 from app.services import national
 from app.services.title_match import titles_agree
 from app.services.item_write import insert_item
+from app.services.write_targets import UnknownLocationError, validated_location_id
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/intake", dependencies=[Depends(require_role("editor"))])
 
 MAX_PHOTO_DIMENSION = 100_000  # sanity bound on client-reported pixels
+_LOCATION_ERROR = "Selected location no longer exists — choose another location"
 
 # Same five types cover enrichment treats as the book catalogue.
 BOOK_SEARCH_MEDIA_TYPES = cover_queue.COVER_REQUEUE_MEDIA_TYPES
@@ -200,8 +202,9 @@ async def _confirm_one(
                     item_id = items_common._save_item(metadata, printed_isbn13, media_type,
                                          location_id, "photo_intake", hc_ids)
                 except sqlite3.IntegrityError:
-                    # A bad location_id raises the same exception (FK,
-                    # PRAGMA foreign_keys=ON) — classify before labelling.
+                    # A location deleted after the boundary check can still
+                    # raise the same FK exception; classify ISBN races before
+                    # allowing the invariant failure to propagate.
                     if _isbn_taken(printed_isbn13, media_type):
                         return "skipped", {
                             "title": title, "reason": "ISBN already in library"}, None
@@ -274,9 +277,8 @@ async def _confirm_one(
             if taken:
                 return "skipped", {"title": title, "reason": "ISBN already in library"}, None
 
-        # 5. Insert. A bad location_id also raises IntegrityError (FK,
-        # PRAGMA foreign_keys=ON) — classify before labelling it an ISBN
-        # duplicate.
+        # 5. Insert. A location deleted after the boundary check can still
+        # fail the FK invariant here; an ISBN race is classified separately.
         try:
             item_id = insert_item(
                 db,
@@ -310,6 +312,12 @@ async def _confirm_one(
 @router.post("/confirm")
 async def confirm_books(payload: IntakeConfirm):
     """Insert confirmed candidates as items via the normal metadata pipeline."""
+    try:
+        with get_db() as db:
+            location_id = validated_location_id(db, payload.location_id)
+    except UnknownLocationError:
+        return {"ok": False, "message": _LOCATION_ERROR}
+
     added, skipped = [], []
     new_item_ids: list[int] = []
 
@@ -327,7 +335,7 @@ async def confirm_books(payload: IntakeConfirm):
                 continue
 
             status, entry, item_id = await _confirm_one(
-                book, client, search_lang, preferred_marc, payload.location_id,
+                book, client, search_lang, preferred_marc, location_id,
                 payload.owned, hc_token, google_api_key)
             if status == "added":
                 added.append(entry)

--- a/app/services/write_targets.py
+++ b/app/services/write_targets.py
@@ -1,0 +1,30 @@
+"""Validation helpers for foreign-key-like targets supplied by write requests.
+
+Routes should validate stale/tampered target ids before doing outbound work or
+attempting an INSERT. SQLite's foreign-key exception is the final invariant,
+not a user-facing control-flow mechanism.
+"""
+
+
+class UnknownLocationError(ValueError):
+    """A positive location id was supplied but no such location exists."""
+
+
+def validated_location_id(db, location_id: int | None) -> int | None:
+    """Return a usable location id, or ``None`` for the no-location sentinel.
+
+    Existing forms historically treat zero/negative values as "no location";
+    keep that compatibility. A positive id is different: it represents an
+    explicit selection and must still exist when the mutation reaches the
+    server, otherwise the caller gets ``UnknownLocationError`` rather than a
+    later SQLite ``IntegrityError``.
+    """
+    if location_id is None or location_id <= 0:
+        return None
+    row = db.execute(
+        "SELECT 1 FROM locations WHERE id = ?",
+        (location_id,),
+    ).fetchone()
+    if row is None:
+        raise UnknownLocationError(f"Location {location_id} not found")
+    return location_id

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -2,7 +2,6 @@
 import functools
 import json
 import logging
-import sqlite3
 
 import anthropic
 import httpx
@@ -904,13 +903,17 @@ class TestConfirmEndpoint:
         assert data["added"][1]["matched"] is False
 
     @respx.mock
-    def test_bad_location_is_not_reported_as_isbn_duplicate(self, admin_client, db):
-        respx.get(OL_SEARCH_URL).mock(return_value=httpx.Response(200, json={"docs": []}))
-        with pytest.raises(sqlite3.IntegrityError):
-            admin_client.post("/api/intake/confirm", json={
-                "books": [{"title": "Bad Location Book", "authors": None}],
-                "location_id": 999999,
-            })
+    def test_bad_location_is_rejected_before_metadata_or_insert(self, admin_client, db):
+        route = respx.get(OL_SEARCH_URL).mock(return_value=httpx.Response(200, json={"docs": []}))
+        resp = admin_client.post("/api/intake/confirm", json={
+            "books": [{"title": "Bad Location Book", "authors": None}],
+            "location_id": 999999,
+        })
+        assert resp.json() == {
+            "ok": False,
+            "message": "Selected location no longer exists — choose another location",
+        }
+        assert route.called is False
         row = db.execute("SELECT id FROM items WHERE title = 'Bad Location Book'").fetchone()
         assert row is None
 
@@ -1144,17 +1147,22 @@ class TestConfirmWithIsbn:
         enrich.assert_called_once_with([strong, weak])
 
     @respx.mock
-    def test_bad_location_on_strong_path_is_not_reported_as_isbn_duplicate(
-            self, admin_client, monkeypatch):
-        # The strong path has its own IntegrityError handler; a FK failure
-        # there must re-raise, not be labelled an ISBN duplicate either.
-        _patch_lookup(monkeypatch, result=(FULL_META, "openlibrary", {}, False))
-        respx.get(OL_SEARCH_URL).mock(return_value=httpx.Response(200, json={"docs": []}))
-        with pytest.raises(sqlite3.IntegrityError):
-            admin_client.post("/api/intake/confirm", json={
-                "books": [{"title": "Dune", "isbn": ISBN13}],
-                "location_id": 999999,
-            })
+    def test_bad_location_on_strong_path_is_rejected_before_cascade(
+            self, admin_client, db, monkeypatch):
+        calls = []
+        _patch_lookup(monkeypatch, result=(FULL_META, "openlibrary", {}, False), record=calls)
+        route = respx.get(OL_SEARCH_URL).mock(return_value=httpx.Response(200, json={"docs": []}))
+        resp = admin_client.post("/api/intake/confirm", json={
+            "books": [{"title": "Dune", "isbn": ISBN13}],
+            "location_id": 999999,
+        })
+        assert resp.json() == {
+            "ok": False,
+            "message": "Selected location no longer exists — choose another location",
+        }
+        assert calls == []
+        assert route.called is False
+        assert db.execute("SELECT id FROM items WHERE title = 'Dune'").fetchone() is None
 
     @respx.mock
     def test_integrity_error_is_classified_on_strong_path(self, admin_client, db, monkeypatch):


### PR DESCRIPTION
## Summary
- introduce a small shared write-target validator for location IDs
- preserve the existing zero/negative no-location sentinel
- reject a stale positive Photo Intake location before integration settings, HTTP clients, metadata lookups or inserts
- return a stable user-facing error rather than leaking a SQLite foreign-key failure
- add regressions for both weak and ISBN-first Intake paths

## Testing
Exact upstream diff: Intake +14/-6, new 30-line helper, and the existing Intake regressions updated to prove no provider work occurs.