### PR TITLE
Align Viewer UI with backend permissions

### DIFF
--- a/app/templates/discover.html
+++ b/app/templates/discover.html
@@ -6,8 +6,12 @@
 
     {% if not has_hardcover %}
     <div class="bg-shelf-card rounded-xl border border-shelf-border p-8 text-center">
+        {% if user and user.role == 'admin' %}
         <p class="text-shelf-muted mb-3">Connect your Hardcover account to search for books and add them to your wishlist.</p>
         <a href="/settings" class="px-4 py-2 bg-shelf-accent text-white rounded-lg text-sm hover:bg-shelf-accent2 transition-colors inline-block">Go to Settings</a>
+        {% else %}
+        <p class="text-shelf-muted">Hardcover is not connected. Ask an administrator to configure the integration.</p>
+        {% endif %}
     </div>
     {% else %}
     <div x-data="{ query: '' }">
@@ -23,7 +27,11 @@
 
         <!-- Results -->
         <div id="hc-results">
+            {% if user and user.role in ('admin', 'editor') %}
             <p class="text-shelf-muted text-sm text-center py-8">Search Hardcover's catalog to find books and add them to your wishlist.</p>
+            {% else %}
+            <p class="text-shelf-muted text-sm text-center py-8">Search Hardcover's catalog to explore books.</p>
+            {% endif %}
         </div>
     </div>
     {% endif %}

--- a/app/templates/fragments/hardcover_search_results.html
+++ b/app/templates/fragments/hardcover_search_results.html
@@ -1,3 +1,4 @@
+{% set can_edit = user and user.role in ('admin', 'editor') %}
 {% if not results and query %}
 <p class="text-shelf-muted text-sm text-center py-8">No results for "{{ query }}"</p>
 {% elif results %}
@@ -31,8 +32,8 @@
             <p class="text-xs text-shelf-muted mt-1.5 line-clamp-2">{{ book.description[:200] }}</p>
             {% endif %}
 
-            <!-- Add button -->
             <div class="mt-2">
+                {% if can_edit %}
                 <button x-show="!added"
                         @click="addBook($event)"
                         data-book='{{ book|tojson }}'
@@ -45,6 +46,11 @@
                 <template x-if="error && !added">
                     <span class="text-xs text-shelf-error" x-text="error"></span>
                 </template>
+                {% elif book.in_shelf %}
+                <span class="text-xs text-shelf-success">In your library</span>
+                {% else %}
+                <span class="text-xs text-shelf-muted">Not in your library</span>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/app/templates/item_detail.html
+++ b/app/templates/item_detail.html
@@ -135,7 +135,7 @@
                 {% endif %}
 
                 <!-- Hardcover Sync -->
-                {% if has_hardcover %}
+                {% if has_hardcover and user and user.role in ('admin', 'editor') %}
                 <div class="mb-4" x-data="hardcoverPush" data-item-id="{{ item.id }}">
                     <button @click="push"
                             :disabled="hcPushing"
@@ -187,6 +187,7 @@
                 </div>
 
                 <!-- Lending -->
+                {% if (user and user.role in ('admin', 'editor')) or current_checkout or checkout_history %}
                 <div class="mb-6" x-data="{ showLendForm: false }">
                     <p class="text-sm font-medium text-shelf-muted mb-2">Lending</p>
                     {% if current_checkout %}
@@ -197,13 +198,15 @@
                          · Due: <span class="{% if current_checkout.due_date < now_date %}text-shelf-error{% endif %}">{{ current_checkout.due_date }}</span>
                         {% endif %}
                         </p>
+                        {% if user and user.role in ('admin', 'editor') %}
                         <form action="/api/checkouts/{{ current_checkout.id }}/checkin" method="post" class="mt-2">
                             <button type="submit" class="px-3 py-1 bg-shelf-success/20 text-shelf-success rounded text-xs hover:bg-shelf-success/30 transition-colors">
                                 Check In
                             </button>
                         </form>
+                        {% endif %}
                     </div>
-                    {% else %}
+                    {% elif user and user.role in ('admin', 'editor') %}
                     <button @click="showLendForm = !showLendForm"
                             class="px-3 py-1.5 bg-shelf-card border border-shelf-border text-shelf-muted rounded-lg text-xs hover:border-shelf-accent/50 transition-colors">
                         Lend this item
@@ -249,6 +252,7 @@
                     </details>
                     {% endif %}
                 </div>
+                {% endif %}
 
                 <!-- Actions -->
                 <div class="flex gap-3">

--- a/app/templates/series.html
+++ b/app/templates/series.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Series — Shelf{% endblock %}
 {% block content %}
+{% set can_edit = user and user.role in ('admin', 'editor') %}
 <div class="mb-6">
     <h1 class="text-2xl font-bold">Series <span class="text-shelf-muted text-lg font-normal">({{ series_list|length }})</span></h1>
     <p class="text-sm text-shelf-muted mt-1">Your library grouped by series. Gaps are inferred from position numbers{% if has_hardcover %}; use <span class="text-shelf-accent2">Check completeness</span> to compare against Hardcover's full series listing{% endif %}.</p>
@@ -64,7 +65,7 @@
                 </p>
             </div>
             <div class="flex items-center gap-2 shrink-0">
-                {% if has_hardcover %}
+                {% if has_hardcover and can_edit %}
                 <button @click="fetchDescription"
                         :disabled="fetching"
                         class="px-3 py-1.5 bg-shelf-card border border-shelf-border text-shelf-muted rounded-lg text-xs hover:text-shelf-text hover:border-shelf-accent/50 transition-colors disabled:opacity-50"
@@ -72,6 +73,8 @@
                     <span x-show="!fetching">Fetch synopsis</span>
                     <span x-show="fetching" style="display:none">Fetching&hellip;</span>
                 </button>
+                {% endif %}
+                {% if has_hardcover %}
                 <button @click="check"
                         :disabled="checking"
                         class="px-3 py-1.5 bg-shelf-accent/20 text-shelf-accent2 rounded-lg text-xs hover:bg-shelf-accent/30 transition-colors disabled:opacity-50"
@@ -80,8 +83,8 @@
                     <span x-show="checking" style="display:none">Checking&hellip;</span>
                 </button>
                 {% endif %}
-                <!-- Outside the has_hardcover gate: rename/disband are local
-                     operations and must be reachable without a token. -->
+                {% if can_edit %}
+                <!-- Rename/disband are local mutations and do not depend on Hardcover. -->
                 <div class="relative">
                     <button @click="toggleMenu" aria-label="Series actions"
                             class="px-2 py-1.5 bg-shelf-card border border-shelf-border text-shelf-muted rounded-lg text-xs leading-none hover:text-shelf-text hover:border-shelf-accent/50 transition-colors"
@@ -102,9 +105,11 @@
                                 data-testid="remove-all">Remove all books&hellip;</button>
                     </div>
                 </div>
+                {% endif %}
             </div>
         </div>
 
+        {% if can_edit %}
         <!-- Rename / merge -->
         <div x-show="renaming" style="display:none" class="mt-3 border-t border-shelf-border pt-3">
             <p class="text-xs text-shelf-muted mb-1">Rename this series. Typing the name of another series merges the two.</p>
@@ -143,19 +148,23 @@
                 <span x-show="removeError" style="display:none" class="text-xs text-shelf-error" x-text="removeError"></span>
             </div>
         </div>
+        {% endif %}
 
         <!-- Series synopsis: read view + inline edit -->
         <div class="mt-3">
             <div x-show="!editing">
                 <p x-show="description" class="text-sm text-shelf-muted leading-relaxed whitespace-pre-line"
                    x-text="description" data-testid="series-synopsis"></p>
+                {% if can_edit %}
                 <button @click="startEdit"
                         class="text-xs text-shelf-accent2 hover:text-shelf-text transition-colors mt-1"
                         data-testid="edit-synopsis">
                     <span x-show="description">Edit synopsis</span>
                     <span x-show="!description">+ Add synopsis</span>
                 </button>
+                {% endif %}
             </div>
+            {% if can_edit %}
             <div x-show="editing" style="display:none">
                 <textarea x-model="draft" rows="4" placeholder="What is this series about?"
                           class="w-full bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-sm text-shelf-text focus:ring-2 focus:ring-shelf-accent focus:border-transparent outline-none placeholder-shelf-muted/50"
@@ -172,6 +181,7 @@
                     <span x-show="descError" style="display:none" class="text-xs text-shelf-error" x-text="descError"></span>
                 </div>
             </div>
+            {% endif %}
         </div>
 
         <!-- Owned/wishlisted volumes -->
@@ -214,12 +224,14 @@
                             <span class="text-shelf-muted w-10 shrink-0 text-right" x-text="b.series_position !== null ? '#' + b.series_position : ''"></span>
                             <span class="text-shelf-text truncate" x-text="b.title"></span>
                             <span class="text-shelf-muted text-xs truncate" x-text="b.authors || ''"></span>
+                            {% if can_edit %}
                             <button x-show="!added[b.hardcover_book_id]"
                                     @click="addToWishlist(b)"
                                     class="ml-auto px-2 py-0.5 bg-shelf-accent/20 text-shelf-accent2 rounded text-xs hover:bg-shelf-accent/30 transition-colors shrink-0">
                                 + Wishlist
                             </button>
                             <span x-show="added[b.hardcover_book_id]" style="display:none" class="ml-auto text-xs text-shelf-success shrink-0">Wishlisted</span>
+                            {% endif %}
                         </div>
                     </template>
                 </div>

--- a/tests/e2e/test_lending.py
+++ b/tests/e2e/test_lending.py
@@ -1,0 +1,193 @@
+"""E2E product-smoke journeys for lending and viewer permissions."""
+import sqlite3
+
+import pytest
+from playwright.sync_api import expect
+
+from tests.e2e.conftest import assert_page_clean, attach_page_guard, insert_item
+
+pytestmark = pytest.mark.e2e
+
+
+def _insert_borrower(data_dir, name: str) -> int:
+    conn = sqlite3.connect(str(data_dir / "shelf.db"))
+    try:
+        cur = conn.execute("INSERT INTO borrowers (name) VALUES (?)", (name,))
+        conn.commit()
+        return cur.lastrowid
+    finally:
+        conn.close()
+
+
+def _insert_active_checkout(data_dir, item_id: int, borrower_id: int) -> None:
+    conn = sqlite3.connect(str(data_dir / "shelf.db"))
+    try:
+        conn.execute(
+            "INSERT INTO checkouts (item_id, borrower_id, due_date) "
+            "VALUES (?, ?, date('now', '+14 days'))",
+            (item_id, borrower_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _csrf_headers(page):
+    return {"X-CSRF-Token": page.evaluate("() => window.csrfToken()")}
+
+
+def test_item_page_lend_then_return_full_journey(live_server, authed_page):
+    """A normal household lend/return cycle works end to end from item detail."""
+    borrower = "E2E Lending Friend"
+    _insert_borrower(live_server["data_dir"], borrower)
+    item_id = insert_item(
+        live_server["data_dir"],
+        title="E2E Lending Journey",
+        isbn="9780907000017",
+    )
+    base = live_server["url"]
+
+    authed_page.goto(f"{base}/item/{item_id}")
+    authed_page.wait_for_load_state("networkidle")
+
+    authed_page.get_by_role("button", name="Lend this item").click()
+    form = authed_page.locator(f'form[action="/api/items/{item_id}/checkout"]')
+    expect(form).to_be_visible()
+    form.locator('select[name="borrower_id"]').select_option(label=borrower)
+    form.locator('select[name="due_days"]').select_option("14")
+    form.get_by_role("button", name="Check Out").click()
+
+    authed_page.wait_for_url(f"{base}/item/{item_id}", timeout=10_000)
+    authed_page.wait_for_load_state("networkidle")
+    expect(authed_page.locator("body")).to_contain_text(f"Lent to {borrower}")
+    expect(authed_page.get_by_role("button", name="Check In")).to_be_visible()
+
+    authed_page.get_by_role("button", name="Check In").click()
+    authed_page.wait_for_url(f"{base}/item/{item_id}", timeout=10_000)
+    authed_page.wait_for_load_state("networkidle")
+
+    expect(authed_page.get_by_role("button", name="Lend this item")).to_be_visible()
+    history = authed_page.locator("details").filter(has_text="Checkout history")
+    expect(history).to_be_visible()
+    history.locator("summary").click()
+    expect(history).to_contain_text(borrower)
+    expect(history).to_contain_text("returned")
+    assert_page_clean(authed_page)
+
+
+def test_viewer_sees_read_only_product_ui_without_editor_mutations(
+    live_server, browser, authed_page
+):
+    """Viewer UI mirrors backend permissions while retaining useful read-only context."""
+    base = live_server["url"]
+    username = "e2eviewer_lending"
+    password = "viewer-password-123"
+
+    # Create a real Viewer through the same admin UI a household would use.
+    authed_page.goto(f"{base}/settings")
+    authed_page.get_by_role("button", name="Users").click()
+    authed_page.wait_for_load_state("networkidle")
+    authed_page.fill('input[placeholder="Username"]', username)
+    authed_page.fill('input[placeholder="Password (min 8 chars)"]', password)
+    authed_page.locator('select[x-model="newRole"]').select_option("viewer")
+    authed_page.get_by_role("button", name="Add User").click()
+    expect(authed_page.locator("span.text-shelf-success")).to_contain_text("created")
+
+    borrower_id = _insert_borrower(live_server["data_dir"], "E2E Viewer Borrower")
+    lent_item_id = insert_item(
+        live_server["data_dir"],
+        title="E2E Viewer Lent Item",
+        isbn="9780907000024",
+    )
+    available_item_id = insert_item(
+        live_server["data_dir"],
+        title="E2E Viewer Available Item",
+        isbn="9780907000031",
+        series_name="E2E Viewer Saga",
+        series_position=1,
+    )
+    _insert_active_checkout(live_server["data_dir"], lent_item_id, borrower_id)
+
+    # Configure Hardcover through the real settings endpoint so its viewer-facing
+    # read-only surfaces render. The test clears it again in finally because the
+    # E2E server and nav cache are shared across files.
+    headers = _csrf_headers(authed_page)
+    resp = authed_page.request.post(
+        f"{base}/api/settings",
+        form={"hardcover_token": "test-hc-token-viewer-smoke"},
+        headers=headers,
+    )
+    assert resp.status in (200, 303)
+
+    ctx = browser.new_context()
+    try:
+        page = attach_page_guard(ctx.new_page())
+        page.goto(f"{base}/login")
+        page.fill("input[name=username]", username)
+        page.fill("input[name=password]", password)
+        page.click("button[type=submit]")
+        page.wait_for_url(f"{base}/browse", timeout=10_000)
+
+        # Viewer navigation exposes read-only product surfaces, not editor/admin tools.
+        for key in ("browse", "store", "series", "discover", "stats"):
+            expect(page.locator(f'[data-nav-tab="{key}"]')).to_be_visible()
+        for key in ("scan", "settings", "logs"):
+            expect(page.locator(f'[data-nav-tab="{key}"]')).to_have_count(0)
+
+        # A Viewer can understand that a book is out, but cannot return or sync it.
+        page.goto(f"{base}/item/{lent_item_id}")
+        page.wait_for_load_state("networkidle")
+        expect(page.locator("body")).to_contain_text("Lent to E2E Viewer Borrower")
+        expect(page.get_by_role("button", name="Check In")).to_have_count(0)
+        expect(page.get_by_role("button", name="Push to Hardcover")).to_have_count(0)
+        expect(page.locator('[data-testid="cover-controls"]')).to_have_count(0)
+        expect(page.get_by_role("link", name="Edit", exact=True)).to_have_count(0)
+        expect(page.get_by_role("button", name="Delete", exact=True)).to_have_count(0)
+        expect(page.locator("body")).to_contain_text("Reading Status")
+
+        # Nor should an available item advertise actions that the server rejects.
+        page.goto(f"{base}/item/{available_item_id}")
+        page.wait_for_load_state("networkidle")
+        expect(page.get_by_role("button", name="Lend this item")).to_have_count(0)
+        expect(page.get_by_role("button", name="Push to Hardcover")).to_have_count(0)
+        expect(page.locator(f'form[action="/api/items/{available_item_id}/checkout"]')).to_have_count(0)
+
+        # Series stays useful to Viewers: Hardcover completeness is read-only and
+        # permitted, while synopsis/wishlist/rename/complete mutations are hidden.
+        page.goto(f"{base}/series")
+        page.wait_for_load_state("networkidle")
+        card = page.locator('[data-testid="series-card"]').filter(has_text="E2E Viewer Saga")
+        expect(card).to_be_visible()
+        expect(card.locator('[data-testid="check-series"]')).to_be_visible()
+        for test_id in ("fetch-synopsis", "series-actions", "edit-synopsis"):
+            expect(card.locator(f'[data-testid="{test_id}"]')).to_have_count(0)
+
+        # Discover remains useful when configured, but its copy is read-only for Viewers.
+        page.goto(f"{base}/discover")
+        page.wait_for_load_state("networkidle")
+        expect(page.locator('input[name="q"]')).to_be_visible()
+        expect(page.locator("body")).to_contain_text("Search Hardcover's catalog to explore books.")
+        expect(page.get_by_role("link", name="Go to Settings", exact=True)).to_have_count(0)
+
+        # If Hardcover becomes unconfigured, a Viewer should be told to ask an
+        # administrator rather than being sent to the Admin-only Settings route.
+        clear = authed_page.request.post(
+            f"{base}/api/settings",
+            form={"hardcover_token": "", "clear_hardcover_token": "on"},
+            headers=headers,
+        )
+        assert clear.status in (200, 303)
+        page.goto(f"{base}/discover")
+        page.wait_for_load_state("networkidle")
+        expect(page.locator("body")).to_contain_text(
+            "Hardcover is not connected. Ask an administrator to configure the integration."
+        )
+        expect(page.get_by_role("link", name="Go to Settings", exact=True)).to_have_count(0)
+        assert_page_clean(page)
+    finally:
+        ctx.close()
+        authed_page.request.post(
+            f"{base}/api/settings",
+            form={"hardcover_token": "", "clear_hardcover_token": "on"},
+            headers=headers,
+        )

--- a/tests/test_viewer_discover_permissions.py
+++ b/tests/test_viewer_discover_permissions.py
@@ -1,0 +1,45 @@
+"""Regression tests for Viewer-facing Discover controls."""
+from unittest.mock import AsyncMock, patch
+
+
+def _configure_hardcover(db):
+    db.execute(
+        "INSERT INTO settings (key, value) VALUES ('hardcover_token', 'test-token') "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+    )
+    db.commit()
+
+
+def _search_result():
+    return {
+        "hardcover_book_id": 987654,
+        "title": "Viewer Permission Probe",
+        "authors": "Test Author",
+    }
+
+
+def test_viewer_discover_results_do_not_offer_wishlist_mutation(viewer_client, db):
+    _configure_hardcover(db)
+    with patch(
+        "app.routers.hardcover.hardcover.search_books",
+        new=AsyncMock(return_value=[_search_result()]),
+    ):
+        resp = viewer_client.get("/api/hardcover/search", params={"q": "permission probe"})
+
+    assert resp.status_code == 200
+    assert "Viewer Permission Probe" in resp.text
+    assert "Add to Wishlist" not in resp.text
+    assert "Not in your library" in resp.text
+
+
+def test_editor_discover_results_keep_wishlist_action(editor_client, db):
+    _configure_hardcover(db)
+    with patch(
+        "app.routers.hardcover.hardcover.search_books",
+        new=AsyncMock(return_value=[_search_result()]),
+    ):
+        resp = editor_client.get("/api/hardcover/search", params={"q": "permission probe"})
+
+    assert resp.status_code == 200
+    assert "Viewer Permission Probe" in resp.text
+    assert "Add to Wishlist" in resp.text


### PR DESCRIPTION
## Summary
- hide item-detail lending/check-in and Hardcover-push mutations from Viewer accounts while preserving loan context
- hide Editor-only Series mutations from Viewers while keeping read-only series and completeness features
- keep Discover searchable for Viewers without showing wishlist mutations or an Admin-only Settings link
- preserve Viewer-permitted reading-status and read-only behaviour
- add a real lend-to-return browser journey and a Viewer-account journey covering item, Series and Discover
- add focused Viewer/Editor Discover rendering regressions

## Why
Several controls were rendered for Viewer accounts even though their endpoints require Editor or Admin. The UI should mirror the existing backend permission contract.