### PR TITLE
Make valuation report printing CSP-safe

### DIFF
--- a/app/templates/valuation_report.html
+++ b/app/templates/valuation_report.html
@@ -18,12 +18,13 @@
         a { text-decoration: none; color: inherit; }
     }
 </style>
+<script src="/static/js/valuation-report.js" defer></script>
 {% endblock %}
 {% block content %}
 <div class="max-w-4xl mx-auto">
     <div class="flex items-center justify-between mb-2">
         <h1 class="text-2xl font-bold">Collection Valuation Report</h1>
-        <button onclick="window.print()" class="no-print px-4 py-2 bg-shelf-hover text-shelf-text rounded-lg text-sm hover:bg-shelf-border transition-colors">
+        <button type="button" data-print-page class="no-print px-4 py-2 bg-shelf-hover text-shelf-text rounded-lg text-sm hover:bg-shelf-border transition-colors">
             Print / Save as PDF
         </button>
     </div>

--- a/static/js/valuation-report.js
+++ b/static/js/valuation-report.js
@@ -1,0 +1,11 @@
+// The valuation report is served under Shelf's strict script-src 'self' CSP.
+// Keep print behaviour in this external script: inline onclick handlers are
+// blocked by the browser and otherwise leave the visible print control inert.
+(function () {
+    var printButton = document.querySelector('[data-print-page]');
+    if (!printButton) return;
+
+    printButton.addEventListener('click', function () {
+        window.print();
+    });
+})();

--- a/tests/e2e/test_valuation.py
+++ b/tests/e2e/test_valuation.py
@@ -1,0 +1,85 @@
+"""E2E product-smoke coverage for the collection valuation report."""
+import sqlite3
+
+import pytest
+from playwright.sync_api import expect
+
+from tests.e2e.conftest import (
+    _run_setup_wizard,
+    assert_page_clean,
+    attach_page_guard,
+    insert_item,
+)
+
+pytestmark = pytest.mark.e2e
+
+
+def test_valuation_report_renders_collection_and_prints_under_csp(
+    server_factory, browser
+):
+    """The insurance report is useful and its visible print control actually works."""
+    server = server_factory()
+    base = server["url"]
+    credentials = _run_setup_wizard(browser, base)
+
+    db_path = server["data_dir"] / "shelf.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        location_id = conn.execute(
+            "INSERT INTO locations (name, sort_order) VALUES (?, ?)",
+            ("Valuation Smoke Shelf", 1),
+        ).lastrowid
+        conn.commit()
+    finally:
+        conn.close()
+
+    insert_item(
+        server["data_dir"],
+        title="Manual Value Smoke Book",
+        media_type="book",
+        isbn="9780907000208",
+        authors="Smoke Valuer",
+        location_id=location_id,
+        estimated_value=25.0,
+        manual_value=40.0,
+    )
+    insert_item(
+        server["data_dir"],
+        title="Estimated Value Smoke Book",
+        media_type="book",
+        isbn="9780907000215",
+        authors="Smoke Valuer",
+        location_id=location_id,
+        estimated_value=15.0,
+    )
+
+    ctx = browser.new_context()
+    try:
+        page = attach_page_guard(ctx.new_page())
+        page.goto(f"{base}/login")
+        page.fill("input[name=username]", credentials["username"])
+        page.fill("input[name=password]", credentials["password"])
+        page.click("button[type=submit]")
+        page.wait_for_url(f"{base}/browse", timeout=10_000)
+
+        page.goto(f"{base}/api/valuation/report")
+        page.wait_for_load_state("networkidle")
+        expect(page.get_by_role("heading", name="Collection Valuation Report")).to_be_visible()
+
+        expect(page.locator("body")).to_contain_text("Valuation Smoke Shelf")
+        expect(page.locator("body")).to_contain_text("Manual Value Smoke Book")
+        expect(page.locator("body")).to_contain_text("Estimated Value Smoke Book")
+        expect(page.get_by_text("manual", exact=True)).to_be_visible()
+        expect(page.get_by_text("Total (priced items)").locator("..")).to_contain_text("$55.00")
+
+        # The old inline onclick handler was refused by script-src 'self', so
+        # the visible print button looked usable but did nothing in a browser.
+        page.evaluate(
+            "window.__shelfPrintCalled = false; "
+            "window.print = function () { window.__shelfPrintCalled = true; };"
+        )
+        page.get_by_role("button", name="Print / Save as PDF").click()
+        assert page.evaluate("window.__shelfPrintCalled") is True
+        assert_page_clean(page)
+    finally:
+        ctx.close()


### PR DESCRIPTION
## Summary

* replace the valuation report's inline `onclick="window.print()"` handler with a CSP-safe external script
* keep the visible **Print / Save as PDF** control working under Shelf's existing `script-src 'self'` policy
* add a real browser product-smoke journey that verifies valuation contents, manual-value handling, and the print action itself

## Why

The report currently renders correctly but its main output action is silently blocked by the application's Content Security Policy because inline script handlers are not permitted.

This was found while continuing the product-smoke audit: unit coverage proves the report HTML and totals, but only a browser-level click exposes that the visible print button is inert.

## Testing

This branch is one commit rebuilt directly from current upstream `main` (`a3910c1`) and contains only the valuation-report fix plus its focused E2E regression.
