### PR TITLE
Roll up remaining audit integrity fixes

### DIFF
--- a/app/routers/checkouts.py
+++ b/app/routers/checkouts.py
@@ -1,7 +1,7 @@
 from datetime import date, timedelta
 
 from fastapi import APIRouter, Depends, Form, Request
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 
 from app.auth import require_role
 from app.database import get_db, get_setting
@@ -47,12 +47,26 @@ def get_overdue_loans(db) -> list[dict]:
     return [dict(row) for row in rows]
 
 
+def _borrower_settings_error(code: str) -> RedirectResponse:
+    return RedirectResponse(url=f"/settings?borrower_error={code}", status_code=303)
+
+
 # --- Borrowers ---
 
 @router.post("/borrowers")
 async def create_borrower(name: str = Form(...), _=Depends(require_role("admin"))):
+    clean_name = name.strip()
+    if not clean_name:
+        return JSONResponse(
+            {"ok": False, "message": "Borrower name is required"}, status_code=400
+        )
     with get_db() as db:
-        db.execute("INSERT OR IGNORE INTO borrowers (name) VALUES (?)", (name.strip(),))
+        existing = db.execute(
+            "SELECT id FROM borrowers WHERE name = ?", (clean_name,)
+        ).fetchone()
+        if existing:
+            return _borrower_settings_error("duplicate")
+        db.execute("INSERT INTO borrowers (name) VALUES (?)", (clean_name,))
     return RedirectResponse(url="/settings", status_code=303)
 
 
@@ -66,14 +80,14 @@ async def delete_borrower(borrower_id: int, _=Depends(require_role("admin"))):
     matching what deleting a location or a platform already does.
     """
     with get_db() as db:
-        # Take the write lock *before* reading the guard. sqlite3 opens no
-        # transaction for a bare SELECT, so without this the active-loan
-        # count is read outside any lock and a checkout committed between
-        # that read and the DELETE below would be destroyed as "history".
-        # The foreign key used to make that interleaving fail safe; the
-        # cascade removes that accidental protection, so the lock replaces
-        # it. Read, decide, and write are now one serialized unit.
+        # Take the write lock *before* reading either existence or the active-
+        # loan guard. This serializes the decision with checkout creation.
         db.execute("BEGIN IMMEDIATE")
+        borrower = db.execute(
+            "SELECT id FROM borrowers WHERE id = ?", (borrower_id,)
+        ).fetchone()
+        if not borrower:
+            return _borrower_settings_error("missing")
         active = db.execute(
             "SELECT COUNT(*) as c FROM checkouts WHERE borrower_id = ? AND checked_in IS NULL",
             (borrower_id,),
@@ -97,11 +111,27 @@ async def checkout_item(
     _=Depends(require_role("editor")),
 ):
     """Check out an item to a borrower."""
-    templates = request.app.state.templates
     due = (date.today() + timedelta(days=due_days)).isoformat() if due_days > 0 else None
 
     with get_db() as db:
-        # Check not already checked out
+        # Guard and insert must be one serialized write decision. Without a
+        # write lock, two requests can both observe no active checkout before
+        # either INSERT commits and create contradictory simultaneous loans.
+        db.execute("BEGIN IMMEDIATE")
+        item = db.execute("SELECT id FROM items WHERE id = ?", (item_id,)).fetchone()
+        if not item:
+            return JSONResponse(
+                {"ok": False, "message": "Item not found"}, status_code=404
+            )
+
+        borrower = db.execute(
+            "SELECT id FROM borrowers WHERE id = ?", (borrower_id,)
+        ).fetchone()
+        if not borrower:
+            return JSONResponse(
+                {"ok": False, "message": "Borrower not found"}, status_code=404
+            )
+
         active = db.execute(
             "SELECT id FROM checkouts WHERE item_id = ? AND checked_in IS NULL", (item_id,)
         ).fetchone()

--- a/app/routers/hardcover.py
+++ b/app/routers/hardcover.py
@@ -5,7 +5,7 @@ import re
 
 import httpx
 from fastapi import APIRouter, Depends, Form, Request
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from starlette.responses import StreamingResponse
 
 from app.auth import require_role
@@ -31,8 +31,17 @@ HC_STATUSES = {
 @router.post("/test")
 async def test_hardcover(request: Request, _=Depends(require_role("admin"))):
     """Test a Hardcover API token."""
-    data = await request.json()
-    token = data.get("token", "").strip()
+    try:
+        data = await request.json()
+    except Exception:
+        return {"ok": False, "message": "Invalid request body"}
+    if not isinstance(data, dict):
+        return {"ok": False, "message": "Invalid request body"}
+
+    raw_token = data.get("token")
+    if raw_token is not None and not isinstance(raw_token, str):
+        return {"ok": False, "message": "Invalid request body"}
+    token = (raw_token or "").strip()
     if not token:
         # Masked field posts empty — test the stored token instead
         with get_db() as db:
@@ -79,8 +88,31 @@ async def search_hardcover(request: Request, q: str = "", _=Depends(require_role
 @router.post("/add-to-shelf")
 async def add_hardcover_to_shelf(request: Request, _=Depends(require_role("editor"))):
     """Add a book from Hardcover search to Shelf as a wishlist item."""
-    data = await request.json()
-    title = data.get("title", "").strip()
+    try:
+        data = await request.json()
+    except Exception:
+        return {"ok": False, "message": "Invalid request body"}
+    if not isinstance(data, dict):
+        return {"ok": False, "message": "Invalid request body"}
+
+    raw_title = data.get("title")
+    if raw_title is not None and not isinstance(raw_title, str):
+        return {"ok": False, "message": "Invalid request body"}
+    for key in ("authors", "isbn", "publisher", "description", "series_name", "cover_url"):
+        value = data.get(key)
+        if value is not None and not isinstance(value, str):
+            return {"ok": False, "message": "Invalid request body"}
+    for key in ("hardcover_book_id", "year", "pages"):
+        value = data.get(key)
+        if value is not None and (isinstance(value, bool) or not isinstance(value, int)):
+            return {"ok": False, "message": "Invalid request body"}
+    series_position = data.get("series_position")
+    if series_position is not None and (
+        isinstance(series_position, bool) or not isinstance(series_position, (int, float))
+    ):
+        return {"ok": False, "message": "Invalid request body"}
+
+    title = (raw_title or "").strip()
     if not title:
         return {"ok": False, "message": "Title required"}
 
@@ -140,7 +172,9 @@ async def add_hardcover_to_shelf(request: Request, _=Depends(require_role("edito
 async def set_hardcover_schedule(interval: str = Form("off"), _=Depends(require_role("admin"))):
     """Set the Hardcover sync schedule."""
     if interval not in ("off", "daily", "weekly"):
-        interval = "off"
+        return JSONResponse(
+            {"ok": False, "message": "Invalid sync interval"}, status_code=400
+        )
     with get_db() as db:
         db.execute(
             "INSERT INTO settings (key, value) VALUES ('hc_sync_interval', ?) "

--- a/app/routers/items.py
+++ b/app/routers/items.py
@@ -32,17 +32,6 @@ from app.services import authors as authors_svc
 router = APIRouter(prefix="/api")
 
 
-
-
-
-
-
-
-
-
-
-
-
 def _find_duplicate_item(db, isbn13: str | None, upc_code: str | None, media_type: str) -> dict | None:
     """Existing item carrying this barcode for this media type, if any.
 
@@ -64,12 +53,6 @@ def _find_duplicate_item(db, isbn13: str | None, upc_code: str | None, media_typ
         ).fetchone()
         if row:
             return dict(row)
-        # Rows written before #20 kept the barcode in items.isbn, zero-padded
-        # by to_isbn13() — the same canonical form normalize_upc() produces,
-        # so this matches them exactly. Migration 21 re-files them, but it
-        # skips any row whose move would collide, and an older instance may
-        # still share the database. No real ISBN can land here: ISBN-13 is
-        # always 978/979, which detect_barcode_type() classifies as an ISBN.
         row = db.execute(
             "SELECT id, title FROM items WHERE isbn = ? AND media_type = ?",
             (upc_code, media_type),
@@ -82,8 +65,6 @@ def _find_duplicate_item(db, isbn13: str | None, upc_code: str | None, media_typ
 def _find_item_by_barcode(raw: str) -> dict | None:
     """Find an existing item by ISBN or UPC barcode. Returns dict or None."""
     barcode_type = upc_svc.detect_barcode_type(raw)
-    # to_isbn13() zero-pads a UPC-A into an ISBN-shaped string, so a UPC must
-    # not be looked up against items.isbn — that is what mis-filed them (#20).
     isbn13 = isbn_svc.to_isbn13(raw) if barcode_type != "upc" else None
     upc_norm = upc_svc.normalize_upc(raw) if barcode_type == "upc" else None
 
@@ -116,7 +97,6 @@ def _scan_mode_lend(request, templates, item: dict, borrower_id: int | None, raw
         )
 
     with get_db() as db:
-        # Check if already checked out
         active = db.execute(
             "SELECT c.id, b.name FROM checkouts c JOIN borrowers b ON c.borrower_id = b.id "
             "WHERE c.item_id = ? AND c.checked_in IS NULL", (item["id"],)
@@ -143,13 +123,12 @@ def _scan_mode_lend(request, templates, item: dict, borrower_id: int | None, raw
         )
 
     items_common._log_scan(raw, item.get("media_type", ""), "checked_out", item["id"], "lend")
-    resp = templates.TemplateResponse(
+    return templates.TemplateResponse(
         request, "fragments/scan_result.html",
         {"status": "checked_out", "isbn": raw, "title": item["title"],
          "item_id": item["id"], "cover_path": item.get("cover_path"),
          "authors": item.get("authors"), "message": f"Lent to {borrower['name']}"},
     )
-    return resp
 
 
 def _scan_mode_return(request, templates, item: dict, raw: str):
@@ -167,19 +146,15 @@ def _scan_mode_return(request, templates, item: dict, raw: str):
                  "item_id": item["id"], "cover_path": item.get("cover_path"),
                  "message": "Not currently checked out"},
             )
-
-        db.execute(
-            "UPDATE checkouts SET checked_in = datetime('now') WHERE id = ?", (active["id"],)
-        )
+        db.execute("UPDATE checkouts SET checked_in = datetime('now') WHERE id = ?", (active["id"],))
 
     items_common._log_scan(raw, item.get("media_type", ""), "returned", item["id"], "return")
-    resp = templates.TemplateResponse(
+    return templates.TemplateResponse(
         request, "fragments/scan_result.html",
         {"status": "returned", "isbn": raw, "title": item["title"],
          "item_id": item["id"], "cover_path": item.get("cover_path"),
          "authors": item.get("authors"), "message": f"Returned from {active['name']}"},
     )
-    return resp
 
 
 def _scan_mode_move(request, templates, item: dict, location_id: int | None, raw: str):
@@ -191,20 +166,23 @@ def _scan_mode_move(request, templates, item: dict, location_id: int | None, raw
         )
 
     old_location = item.get("location_name") or "No location"
-
     with get_db() as db:
-        db.execute("UPDATE items SET location_id = ? WHERE id = ?", (location_id, item["id"]))
         new_loc = db.execute("SELECT name FROM locations WHERE id = ?", (location_id,)).fetchone()
+        if not new_loc:
+            return templates.TemplateResponse(
+                request, "fragments/scan_result.html",
+                {"status": "error", "isbn": raw, "message": "Location not found"},
+            )
+        db.execute("UPDATE items SET location_id = ? WHERE id = ?", (location_id, item["id"]))
 
-    new_name = new_loc["name"] if new_loc else "Unknown"
+    new_name = new_loc["name"]
     items_common._log_scan(raw, item.get("media_type", ""), "moved", item["id"], "move")
-    resp = templates.TemplateResponse(
+    return templates.TemplateResponse(
         request, "fragments/scan_result.html",
         {"status": "moved", "isbn": raw, "title": item["title"],
          "item_id": item["id"], "cover_path": item.get("cover_path"),
          "authors": item.get("authors"), "message": f"{old_location} → {new_name}"},
     )
-    return resp
 
 
 def _scan_mode_inventory(request, templates, item: dict | None, location_id: int | None, raw: str):
@@ -217,7 +195,12 @@ def _scan_mode_inventory(request, templates, item: dict | None, location_id: int
 
     with get_db() as db:
         loc = db.execute("SELECT name FROM locations WHERE id = ?", (location_id,)).fetchone()
-    loc_name = loc["name"] if loc else "Unknown"
+    if not loc:
+        return templates.TemplateResponse(
+            request, "fragments/scan_result.html",
+            {"status": "error", "isbn": raw, "message": "Location not found"},
+        )
+    loc_name = loc["name"]
 
     if not item:
         items_common._log_scan(raw, "", "not_owned", None, "inventory")
@@ -234,19 +217,18 @@ def _scan_mode_inventory(request, templates, item: dict | None, location_id: int
              "item_id": item["id"], "cover_path": item.get("cover_path"),
              "authors": item.get("authors"), "message": f"Confirmed at {loc_name}"},
         )
-    else:
-        old_location = item.get("location_name") or "No location"
-        # Update location to where it actually is
-        with get_db() as db:
-            db.execute("UPDATE items SET location_id = ? WHERE id = ?", (location_id, item["id"]))
-        items_common._log_scan(raw, item.get("media_type", ""), "relocated", item["id"], "inventory")
-        return templates.TemplateResponse(
-            request, "fragments/scan_result.html",
-            {"status": "relocated", "isbn": raw, "title": item["title"],
-             "item_id": item["id"], "cover_path": item.get("cover_path"),
-             "authors": item.get("authors"),
-             "message": f"Was at {old_location}, updated to {loc_name}"},
-        )
+
+    old_location = item.get("location_name") or "No location"
+    with get_db() as db:
+        db.execute("UPDATE items SET location_id = ? WHERE id = ?", (location_id, item["id"]))
+    items_common._log_scan(raw, item.get("media_type", ""), "relocated", item["id"], "inventory")
+    return templates.TemplateResponse(
+        request, "fragments/scan_result.html",
+        {"status": "relocated", "isbn": raw, "title": item["title"],
+         "item_id": item["id"], "cover_path": item.get("cover_path"),
+         "authors": item.get("authors"),
+         "message": f"Was at {old_location}, updated to {loc_name}"},
+    )
 
 
 def _scan_mode_lookup(request, templates, item: dict | None, raw: str):
@@ -278,16 +260,14 @@ def _scan_mode_quick_rate(request, templates, item: dict, raw: str):
         )
 
     items_common._log_scan(raw, item.get("media_type", ""), "marked_read", item["id"], "quick_rate")
-    resp = templates.TemplateResponse(
+    return templates.TemplateResponse(
         request, "fragments/scan_result.html",
         {"status": "marked_read", "isbn": raw, "title": item["title"],
          "item_id": item["id"], "cover_path": item.get("cover_path"),
          "authors": item.get("authors"), "message": "Marked as read"},
     )
-    return resp
 
 
-# Modes that operate on existing items (not add/wishlist)
 _EXISTING_ITEM_MODES = {"lend", "return", "move", "inventory", "lookup", "quick_rate"}
 
 
@@ -302,10 +282,8 @@ async def scan_isbn(
     templates = request.app.state.templates
     raw = isbn.strip()
 
-    # --- Modes that operate on existing items ---
     if mode in _EXISTING_ITEM_MODES:
         item = _find_item_by_barcode(raw)
-        # inventory mode handles not-found specially
         if mode == "inventory":
             return _scan_mode_inventory(request, templates, item, location_id, raw)
         if not item:
@@ -325,38 +303,27 @@ async def scan_isbn(
         if mode == "quick_rate":
             return _scan_mode_quick_rate(request, templates, item, raw)
 
-    # --- Add / Wishlist modes (create new items) ---
-    # Detect barcode type — route UPC barcodes to DVD/product lookup
     barcode_type = upc_svc.detect_barcode_type(raw)
     if barcode_type == "upc":
-        return await items_common._scan_upc(request, templates, raw, media_type, location_id, platform or None, mode=mode)
+        return await items_common._scan_upc(
+            request, templates, raw, media_type, location_id, platform or None, mode=mode
+        )
 
-    # Normalize ISBN
-    isbn13 = isbn_svc.to_isbn13(raw)
-    if not isbn13:
+    pair = isbn_svc.canonical_isbn_pair(raw)
+    if pair is None:
         items_common._log_scan(isbn, media_type, "error", mode=mode)
         return templates.TemplateResponse(
             request, "fragments/scan_result.html",
             {"status": "error", "isbn": isbn, "message": "Invalid ISBN"},
         )
+    isbn13, _isbn10 = pair
 
-    # §1 — the barcode outranks the dropdown when it is certain. A 978/979
-    # prefix is certain, so a stale "DVD" or "Video Game" in the picker is
-    # overridden to Book here rather than filing a novel as a disc; the
-    # book-family distinctions the barcode genuinely cannot make
-    # (kids_book / audiobook / ebook / comic) are left to the user.
-    #
-    # There is no product record on this branch — an ISBN never reaches UPC
-    # Item DB — so tiers 2 and 3 have nothing to read and tier 1 decides
-    # alone. Everything below this line uses the *resolved* type: the
-    # duplicate check keys on it, and so does the row that gets saved.
     hint = media_type
     detection = detect.detect_media_type(barcode_type, hint, None, None)
     media_type = detection.media_type
     detect_reason = detection.reason
     detect_overrode = media_type != hint
 
-    # Check duplicate
     with get_db() as db:
         existing = db.execute(
             "SELECT id, title FROM items WHERE isbn = ? AND media_type = ?",
@@ -369,28 +336,17 @@ async def scan_isbn(
             {"status": "duplicate", "isbn": isbn13, "title": existing["title"], "item_id": existing["id"]},
         )
 
-    # Get optional metadata-provider credentials.
     with get_db() as db:
         hc_token = get_setting(db, "hardcover_token") or None
         google_api_key = get_setting(db, "google_books_api_key") or None
 
     logger.info("Scanning ISBN %s (type=%s, mode=%s)", isbn13, media_type, mode)
-    # No try/except around this block any more: every leg returns
-    # `transport_failed` rather than raising, and `_fetch_preview_cover`
-    # swallows everything of its own, so the old `httpx.TimeoutException` /
-    # `NetworkError` arms had become dead code that reads as live (G47). The
-    # connectivity card is rendered from the cascade outcome below; the
-    # separate "timed out — try again" wording collapses into it.
     async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
         metadata, source, hc_ids, cascade = await items_common._lookup_metadata(
             isbn13, hc_token, client, google_api_key=google_api_key
         )
 
         if not metadata:
-            # G47 applied to the book path: a cascade that could not reach
-            # anybody is not a book that does not exist. Only an Open
-            # Library exception used to reach this card; the other three
-            # legs swallowed their transport failures into `not_found`.
             if cascade.outcome == "transport_failed":
                 logger.warning("Network error looking up ISBN %s", isbn13)
                 items_common._log_scan(isbn13, media_type, "error", mode=mode)
@@ -402,13 +358,6 @@ async def scan_isbn(
 
             preview_cover = await items_common._fetch_preview_cover(isbn13, client)
             items_common._log_scan(isbn13, media_type, "not_found", mode=mode)
-            # The same vocabulary the added-card notice uses, projected
-            # from the cascade record — so `rejected` reaches the arm
-            # `fragments/scan_result.html` has always carried for it and
-            # the card can name the credential that was refused.
-            # `not_found_status`, not `enrich_status`: this card's own
-            # message already says "Not found", so a `no_match` notice
-            # would repeat it. Both UPC branches project the same way.
             return templates.TemplateResponse(
                 request, "fragments/scan_result.html",
                 {
@@ -423,14 +372,10 @@ async def scan_isbn(
 
         item_id = items_common._save_item(metadata, isbn13, media_type, location_id, source, hc_ids)
 
-        # Wishlist mode: set owned = 0
         if mode == "wishlist":
             with get_db() as db:
                 db.execute("UPDATE items SET owned = 0 WHERE id = ?", (item_id,))
 
-        # Queue the cover instead of downloading it in-request. The
-        # hints are the exact three inputs the download used to take, so
-        # the worker runs the same chain this request would have.
         hc_cover = metadata.get("cover_url") if source == "hardcover" else hc_ids.get("cover_url")
         cover_queue.enqueue(item_id, hints={
             "cover_url": metadata.get("cover_url") if source != "hardcover" else None,
@@ -438,11 +383,9 @@ async def scan_isbn(
             "hardcover_cover_url": hc_cover,
         })
 
-
     status = "wishlisted" if mode == "wishlist" else "added"
     items_common._log_scan(isbn13, media_type, status, item_id, mode)
-
-    resp = templates.TemplateResponse(
+    return templates.TemplateResponse(
         request, "fragments/scan_result.html",
         {
             "status": status,
@@ -454,16 +397,10 @@ async def scan_isbn(
             "item_id": item_id,
             "source": source,
             "media_type_label": MEDIA_TYPES.get(media_type, media_type),
-            # T5 renders these; T4 only has to carry them.
             "detect_reason": detect_reason,
             "detect_overrode": detect_overrode,
         },
     )
-    return resp
-
-
-
-
 
 
 @router.post("/items/manual")
@@ -482,11 +419,6 @@ async def manual_add(request: Request, _=Depends(require_role("editor"))):
     isbn = form.get("isbn", "").strip()
     media_type = form.get("media_type", "book")
 
-    # Guard 3 of 3. The scan not-found card re-emits its media type into a
-    # hidden field (`fragments/scan_result.html`), so whatever that card can
-    # carry arrives here and goes straight to `insert_item` with nothing in
-    # between. Same helper as the other two boundaries — see its comment in
-    # items_common for why there is exactly one.
     if not items_common.is_valid_media_type(media_type):
         return templates.TemplateResponse(
             request, "fragments/scan_result.html",
@@ -494,26 +426,26 @@ async def manual_add(request: Request, _=Depends(require_role("editor"))):
              "message": "Unrecognised media type — pick one and try again"},
         )
 
-    # A UPC belongs in items.upc, never in items.isbn (#20). to_isbn13()
-    # will happily zero-pad a 12-digit UPC-A into something ISBN-shaped, so
-    # every manually-added disc and game used to be filed in the wrong
-    # column: the UPC scan path (which reads items.upc) could never find it
-    # again, and scanning the same barcode a second time offered the manual
-    # form again and then tripped UNIQUE(isbn, media_type) with a 500.
     barcode_type = upc_svc.detect_barcode_type(isbn) if isbn else "unknown"
     if barcode_type == "upc":
         upc_code = upc_svc.normalize_upc(isbn)
         isbn13 = isbn10 = None
+    elif isbn:
+        upc_code = None
+        pair = isbn_svc.canonical_isbn_pair(isbn)
+        if pair is None:
+            return templates.TemplateResponse(
+                request, "fragments/scan_result.html",
+                {"status": "error", "isbn": isbn, "message": "Invalid ISBN"},
+            )
+        isbn13, isbn10 = pair
     else:
         upc_code = None
-        isbn13 = isbn_svc.to_isbn13(isbn) if isbn else None
-        isbn10 = isbn_svc.isbn13_to_isbn10(isbn13) if isbn13 else None
+        isbn13 = isbn10 = None
+
     pub_year = form.get("publish_year")
     platform = form.get("platform") or None
     language = form.get("language", "").strip() or None
-
-    # #19 "copy from" prefill: series_name + location_id are optional and
-    # only reach here if the picker filled them in (or the user typed them).
     series_name = form.get("series_name", "").strip() or None
     if series_name and len(series_name) > MAX_SERIES_NAME:
         series_name = series_name[:MAX_SERIES_NAME]
@@ -552,9 +484,6 @@ async def manual_add(request: Request, _=Depends(require_role("editor"))):
                     source="manual",
                 )
             except sqlite3.IntegrityError:
-                # Lost a race with a concurrent add, or the barcode is on a row
-                # filed before the #20 re-file migration. Either way the user
-                # gets the duplicate card rather than a 500.
                 existing = _find_duplicate_item(db, isbn13, upc_code, media_type)
                 if existing is None:
                     raise
@@ -568,7 +497,6 @@ async def manual_add(request: Request, _=Depends(require_role("editor"))):
              "item_id": existing["id"]},
         )
 
-    # Handle cover upload
     cover_path = None
     cover_file = form.get("cover")
     if cover_file and hasattr(cover_file, "read"):
@@ -576,11 +504,9 @@ async def manual_add(request: Request, _=Depends(require_role("editor"))):
         if content and len(content) > 100:
             cover_path = covers.save_uploaded_cover(item_id, content)
 
-    # If no upload, check for preview cover from scan, then try Amazon
     if not cover_path and isbn13:
         preview_path = covers.COVERS_DIR / f"preview_{isbn13}.jpg"
         if preview_path.exists():
-            # Rename preview to permanent cover
             dest = covers.COVERS_DIR / f"{item_id}.jpg"
             preview_path.rename(dest)
             cover_path = f"covers/{item_id}.jpg"
@@ -593,7 +519,6 @@ async def manual_add(request: Request, _=Depends(require_role("editor"))):
             db.execute("UPDATE items SET cover_path = ? WHERE id = ?", (cover_path, item_id))
 
     items_common._log_scan(isbn13 or upc_code or "", media_type, "added", item_id)
-
     resp = templates.TemplateResponse(
         request, "fragments/scan_result.html",
         {
@@ -613,11 +538,7 @@ async def manual_add(request: Request, _=Depends(require_role("editor"))):
 
 @router.get("/items/suggest")
 async def suggest_items(q: str = "", _=Depends(require_role("editor"))):
-    """Title-prefix suggestions for the manual-add "copy from" picker (#19).
-
-    JSON only (no HTMX fragment) — the picker is a small Alpine dropdown, not
-    a server-rendered list.
-    """
+    """Title-prefix suggestions for the manual-add "copy from" picker (#19)."""
     q = q.strip()[:200]
     if not q:
         return JSONResponse([])
@@ -632,12 +553,7 @@ async def suggest_items(q: str = "", _=Depends(require_role("editor"))):
 
 @router.get("/items/{item_id}/copy-template")
 async def copy_template(item_id: int, _=Depends(require_role("editor"))):
-    """Copyable-field subset of an item for manual-add prefill (#19).
-
-    Explicitly excludes title, isbn/upc, cover, reading status, value, and
-    notes — those are identity/state, not template, fields. Keep this key
-    set in sync with .devdocs/archive/completed/plan-issues-15-18-19-quick-wins.md section B.
-    """
+    """Copyable-field subset of an item for manual-add prefill (#19)."""
     with get_db() as db:
         row = db.execute(
             """SELECT authors, publisher, publish_year, media_type, platform,
@@ -664,56 +580,32 @@ async def search_items(
     per_page: int = DEFAULT_PAGE_SIZE,
     _=Depends(require_role("viewer")),
 ):
-    """Search/filter items. Returns HTMX fragment of item cards.
-
-    Filter values are read from the query string via the registry rather than
-    declared as parameters here — a filter added to `app/browse_filters.py`
-    then needs no change in this signature. Everything is a plain string; the
-    registry owns the per-filter parsing (`location_filter` casts to int, and
-    `owned` is tri-state).
-    """
+    """Search/filter items. Returns HTMX fragment of item cards."""
     templates = request.app.state.templates
-
     values = browse_filters.values_from(request.query_params)
-    # Truncate search query to prevent slow LIKE scans
     values["q"] = values["q"][:200]
     sort = values["sort"]
     view = values["view"]
-
     where, params = browse_filters.build_where(values)
     _, order_clause = SORT_OPTIONS.get(sort, SORT_OPTIONS["newest"])
     offset = (max(page, 1) - 1) * per_page
 
     with get_db() as db:
-        total = db.execute(
-            f"SELECT COUNT(*) as c FROM items i {where}", params
-        ).fetchone()["c"]
-
+        total = db.execute(f"SELECT COUNT(*) as c FROM items i {where}", params).fetchone()["c"]
         from app.routers.checkouts import OVERDUE_CONDITION, get_overdue_days
         items = db.execute(
             f"SELECT i.*, l.name as location_name, "
             f"(SELECT b.name FROM checkouts c JOIN borrowers b ON c.borrower_id = b.id "
             f" WHERE c.item_id = i.id AND c.checked_in IS NULL LIMIT 1) AS lent_to, "
             f"(SELECT 1 FROM checkouts c WHERE c.item_id = i.id AND {OVERDUE_CONDITION} LIMIT 1) AS lent_overdue "
-            f"FROM items i "
-            f"LEFT JOIN locations l ON i.location_id = l.id "
+            f"FROM items i LEFT JOIN locations l ON i.location_id = l.id "
             f"{where} ORDER BY {order_clause} LIMIT ? OFFSET ?",
             [get_overdue_days(db)] + params + [per_page, offset],
         ).fetchall()
-
-        # Cross-filter counts for dropdowns (page 1 only). Each group is the
-        # same where-clause with its own filter excluded, so the number beside
-        # an option says what selecting it would yield. Shared with /browse so
-        # the two routes cannot disagree.
         counts = items_common.filter_counts(db, values, total) if page <= 1 else None
 
     has_more = (offset + per_page) < total
-
-    load_more_url = "/api/search?" + browse_filters.querystring(
-        values, extra=[f"page={page + 1}"]
-    )
-
-    # Page 1: full grid wrapper. Page 2+: just cards/rows (appended via outerHTML swap on load-more).
+    load_more_url = "/api/search?" + browse_filters.querystring(values, extra=[f"page={page + 1}"])
     if page <= 1:
         template = "fragments/item_grid.html"
     elif view == "list":
@@ -735,7 +627,6 @@ async def search_items(
     if counts:
         ctx.update(counts)
         ctx["render_oob_counts"] = True
-
     return templates.TemplateResponse(request, template, ctx)
 
 
@@ -745,13 +636,14 @@ async def bulk_update(request: Request, _=Depends(require_role("admin"))):
     data = await request.json()
     raw_ids = data.get("item_ids", [])
     updates = data.get("updates", {})
-
     if not raw_ids or not updates:
         return {"ok": False, "message": "No items or updates specified"}
 
     try:
-        item_ids = [int(i) for i in raw_ids]
+        item_ids = list(dict.fromkeys(int(i) for i in raw_ids))
     except (ValueError, TypeError):
+        return {"ok": False, "message": "Invalid item IDs"}
+    if any(item_id <= 0 for item_id in item_ids):
         return {"ok": False, "message": "Invalid item IDs"}
 
     allowed = {"media_type", "location_id", "reading_status", "owned", "series_name"}
@@ -759,16 +651,59 @@ async def bulk_update(request: Request, _=Depends(require_role("admin"))):
     if not filtered:
         return {"ok": False, "message": "No valid fields to update"}
 
+    if "media_type" in filtered and filtered["media_type"] not in MEDIA_TYPES:
+        return {"ok": False, "message": "Invalid media type"}
+
     if "series_name" in filtered:
         if filtered["series_name"] == "__clear__":
             filtered["series_name"] = None
-        elif not str(filtered["series_name"]).strip():
-            return {"ok": False, "message": "Series name cannot be empty"}
+        else:
+            series_name = str(filtered["series_name"]).strip()
+            if not series_name:
+                return {"ok": False, "message": "Series name cannot be empty"}
+            if len(series_name) > MAX_SERIES_NAME:
+                return {"ok": False, "message": "Series name is too long"}
+            filtered["series_name"] = series_name
+
+    if "reading_status" in filtered:
+        if filtered["reading_status"] in ("", "__clear__", None):
+            filtered["reading_status"] = None
+        elif filtered["reading_status"] not in {"want_to_read", "reading", "read"}:
+            return {"ok": False, "message": "Invalid reading status"}
+
+    if "owned" in filtered:
+        owned = filtered["owned"]
+        if isinstance(owned, bool):
+            filtered["owned"] = int(owned)
+        elif owned in (0, 1, "0", "1"):
+            filtered["owned"] = int(owned)
+        else:
+            return {"ok": False, "message": "Owned must be 0 or 1"}
+
+    if "location_id" in filtered:
+        raw_location = filtered["location_id"]
+        if raw_location in (None, "", "__clear__"):
+            filtered["location_id"] = None
+        else:
+            try:
+                location_id = int(raw_location)
+            except (TypeError, ValueError):
+                return {"ok": False, "message": "Invalid location"}
+            if location_id <= 0:
+                return {"ok": False, "message": "Invalid location"}
+            filtered["location_id"] = location_id
 
     placeholders = ",".join("?" for _ in item_ids)
     set_clause = ", ".join(f"{k} = ?" for k in filtered)
 
     with get_db() as db:
+        if filtered.get("location_id") is not None:
+            location = db.execute(
+                "SELECT id FROM locations WHERE id = ?", (filtered["location_id"],)
+            ).fetchone()
+            if not location:
+                return {"ok": False, "message": "Location not found"}
+
         old_series_names = []
         if "series_name" in filtered:
             old_series_names = [
@@ -776,52 +711,149 @@ async def bulk_update(request: Request, _=Depends(require_role("admin"))):
                     f"SELECT DISTINCT series_name FROM items WHERE id IN ({placeholders})",
                     item_ids,
                 ).fetchall()
+                if r["series_name"]
             ]
 
-        db.execute(
-            f"UPDATE items SET {set_clause}, updated_at = datetime('now') WHERE id IN ({placeholders})",
-            list(filtered.values()) + item_ids,
-        )
+        try:
+            cursor = db.execute(
+                f"UPDATE items SET {set_clause}, updated_at = datetime('now') WHERE id IN ({placeholders})",
+                list(filtered.values()) + item_ids,
+            )
+        except sqlite3.IntegrityError:
+            return {"ok": False, "message": "Update conflicts with existing catalogue data", "updated": 0}
+        updated = cursor.rowcount
 
         if old_series_names:
             gc_orphaned_series_meta(db, *old_series_names)
 
-    return {"ok": True, "updated": len(item_ids)}
+    if updated == 0:
+        return {"ok": False, "message": "No matching items found", "updated": 0}
+    return {"ok": True, "updated": updated}
+
+
+def _merge_value_missing(value) -> bool:
+    """Whether a merge field is genuinely blank; numeric zero is meaningful."""
+    return value is None or (isinstance(value, str) and not value.strip())
 
 
 @router.post("/items/merge")
 async def merge_items(request: Request, _=Depends(require_role("admin"))):
-    """Merge multiple items into one, keeping the first as primary."""
+    """Merge multiple items into one without discarding related catalogue data."""
     data = await request.json()
     try:
         keep_id = int(data.get("keep_id", 0))
-        merge_ids = [int(i) for i in data.get("merge_ids", [])]
+        merge_ids = list(dict.fromkeys(int(i) for i in data.get("merge_ids", [])))
     except (ValueError, TypeError):
         return {"ok": False, "message": "Invalid item IDs"}
 
     if not keep_id or not merge_ids:
         return {"ok": False, "message": "Specify keep_id and merge_ids"}
+    if keep_id in merge_ids:
+        return {"ok": False, "message": "Primary item cannot be merged into itself"}
 
+    fillable = (
+        "subtitle", "authors", "cover_path", "publisher", "publish_year", "page_count",
+        "description", "series_name", "series_position", "narrator", "duration_mins",
+        "location_id", "abs_id", "notes", "reading_status", "date_started", "date_finished",
+        "estimated_value", "value_updated_at", "hardcover_book_id", "hardcover_edition_id",
+        "hardcover_user_book_id", "platform", "abs_library_id", "manual_value", "language",
+    )
+
+    merged = 0
     with get_db() as db:
-        primary = db.execute("SELECT * FROM items WHERE id = ?", (keep_id,)).fetchone()
-        if not primary:
+        primary_row = db.execute("SELECT * FROM items WHERE id = ?", (keep_id,)).fetchone()
+        if not primary_row:
             return {"ok": False, "message": "Primary item not found"}
+        primary = dict(primary_row)
 
-        _MERGE_FILLABLE = frozenset(["subtitle", "authors", "publisher", "publish_year", "page_count",
-                                      "description", "series_name", "narrator", "isbn"])
-        for mid in merge_ids:
-            other = db.execute("SELECT * FROM items WHERE id = ?", (mid,)).fetchone()
-            if not other:
-                continue
-            for field in _MERGE_FILLABLE:
-                if not primary[field] and other[field]:
-                    db.execute(f"UPDATE items SET {field} = ? WHERE id = ?", (other[field], keep_id))
+        target_ids = [keep_id] + merge_ids
+        target_placeholders = ",".join("?" for _ in target_ids)
+        active_loans = db.execute(
+            f"SELECT COUNT(*) AS c FROM checkouts "
+            f"WHERE checked_in IS NULL AND item_id IN ({target_placeholders})",
+            target_ids,
+        ).fetchone()["c"]
+        if active_loans > 1:
+            return {
+                "ok": False,
+                "message": "Cannot merge items with multiple active loans",
+                "merged": 0,
+            }
 
-            db.execute("UPDATE scan_log SET item_id = ? WHERE item_id = ?", (keep_id, mid))
-            db.execute("UPDATE reading_log SET item_id = ? WHERE item_id = ?", (keep_id, mid))
-            db.execute("DELETE FROM items WHERE id = ?", (mid,))
+        try:
+            for mid in merge_ids:
+                other_row = db.execute("SELECT * FROM items WHERE id = ?", (mid,)).fetchone()
+                if not other_row:
+                    continue
+                other = dict(other_row)
 
-    return {"ok": True, "merged": len(merge_ids)}
+                updates = {}
+                for field in fillable:
+                    if (_merge_value_missing(primary.get(field)) and
+                            not _merge_value_missing(other.get(field))):
+                        updates[field] = other[field]
+                        primary[field] = other[field]
+
+                if not primary.get("isbn") and other.get("isbn"):
+                    updates["isbn"] = other["isbn"]
+                    updates["isbn10"] = other.get("isbn10")
+                    primary["isbn"] = other["isbn"]
+                    primary["isbn10"] = other.get("isbn10")
+                elif (primary.get("isbn") == other.get("isbn") and
+                      not primary.get("isbn10") and other.get("isbn10")):
+                    updates["isbn10"] = other["isbn10"]
+                    primary["isbn10"] = other["isbn10"]
+
+                if not primary.get("upc") and other.get("upc"):
+                    updates["upc"] = other["upc"]
+                    primary["upc"] = other["upc"]
+
+                db.execute("UPDATE scan_log SET item_id = ? WHERE item_id = ?", (keep_id, mid))
+                db.execute("UPDATE reading_log SET item_id = ? WHERE item_id = ?", (keep_id, mid))
+                db.execute("UPDATE checkouts SET item_id = ? WHERE item_id = ?", (keep_id, mid))
+
+                db.execute(
+                    "INSERT OR IGNORE INTO item_tags (item_id, tag_id) "
+                    "SELECT ?, tag_id FROM item_tags WHERE item_id = ?",
+                    (keep_id, mid),
+                )
+                db.execute("DELETE FROM item_tags WHERE item_id = ?", (mid,))
+
+                links = db.execute(
+                    "SELECT item_a_id, item_b_id, link_type, created_at FROM item_links "
+                    "WHERE item_a_id = ? OR item_b_id = ?",
+                    (mid, mid),
+                ).fetchall()
+                for link in links:
+                    item_a = keep_id if link["item_a_id"] == mid else link["item_a_id"]
+                    item_b = keep_id if link["item_b_id"] == mid else link["item_b_id"]
+                    if item_a == item_b:
+                        continue
+                    db.execute(
+                        "INSERT OR IGNORE INTO item_links "
+                        "(item_a_id, item_b_id, link_type, created_at) VALUES (?, ?, ?, ?)",
+                        (item_a, item_b, link["link_type"], link["created_at"]),
+                    )
+                db.execute(
+                    "DELETE FROM item_links WHERE item_a_id = ? OR item_b_id = ?", (mid, mid)
+                )
+
+                db.execute("DELETE FROM items WHERE id = ?", (mid,))
+
+                if updates:
+                    set_clause = ", ".join(f"{field} = ?" for field in updates)
+                    db.execute(
+                        f"UPDATE items SET {set_clause}, updated_at = datetime('now') WHERE id = ?",
+                        list(updates.values()) + [keep_id],
+                    )
+                merged += 1
+        except sqlite3.IntegrityError:
+            db.rollback()
+            return {"ok": False, "message": "Merge conflicts with existing catalogue data", "merged": 0}
+
+    if merged == 0:
+        return {"ok": False, "message": "No matching items found", "merged": 0}
+    return {"ok": True, "merged": merged}
 
 
 @router.post("/items/{item_id}")
@@ -830,59 +862,121 @@ async def update_item(request: Request, item_id: int, _=Depends(require_role("ed
     back_key = nav.back_target(form.get("from"))["key"]
     redirect_url = f"/item/{item_id}" + (f"?from={back_key}" if back_key else "")
     fields = {}
+    int_fields = {
+        "publish_year": "Invalid publish year",
+        "page_count": "Invalid page count",
+        "duration_mins": "Invalid duration",
+        "location_id": "Invalid location",
+    }
+    float_fields = {
+        "series_position": "Invalid series position",
+        "manual_value": "Invalid manual value",
+    }
     for key in ("title", "subtitle", "authors", "isbn", "media_type", "publisher",
                 "publish_year", "page_count", "description", "series_name",
                 "series_position", "narrator", "duration_mins", "location_id", "notes",
                 "reading_status", "date_started", "date_finished", "owned", "platform",
                 "manual_value", "language"):
         val = form.get(key)
-        if val is not None:
-            if val == "" and key != "owned":
-                fields[key] = None
-            elif key in ("publish_year", "page_count", "duration_mins", "location_id"):
-                fields[key] = int(val) if val else None
-            elif key in ("series_position", "manual_value"):
-                fields[key] = float(val) if val else None
-            elif key == "owned":
-                fields[key] = int(val) if val else 0
-            else:
-                fields[key] = val
+        if val is None:
+            continue
+        if val == "" and key != "owned":
+            fields[key] = None
+        elif key in int_fields:
+            try:
+                fields[key] = int(val)
+            except (TypeError, ValueError):
+                return HTMLResponse(int_fields[key], status_code=400)
+        elif key in float_fields:
+            try:
+                fields[key] = float(val)
+            except (TypeError, ValueError):
+                return HTMLResponse(float_fields[key], status_code=400)
+        elif key == "owned":
+            if val not in ("0", "1", 0, 1):
+                return HTMLResponse("Owned must be 0 or 1", status_code=400)
+            fields[key] = int(val)
+        else:
+            fields[key] = val
 
-    # Handle cover upload
+    if "title" in fields:
+        title = str(fields["title"] or "").strip()
+        if not title:
+            return HTMLResponse("Title is required", status_code=400)
+        fields["title"] = title
+
+    if "media_type" in fields and fields["media_type"] not in MEDIA_TYPES:
+        return HTMLResponse("Invalid media type", status_code=400)
+
+    if "reading_status" in fields:
+        if fields["reading_status"] is None:
+            pass
+        elif fields["reading_status"] not in {"want_to_read", "reading", "read"}:
+            return HTMLResponse("Invalid reading status", status_code=400)
+
+    if fields.get("location_id") is not None and fields["location_id"] <= 0:
+        return HTMLResponse("Invalid location", status_code=400)
+
+    if "isbn" in fields:
+        if fields["isbn"] is None:
+            fields["isbn10"] = None
+        else:
+            pair = isbn_svc.canonical_isbn_pair(str(fields["isbn"]))
+            if pair is None:
+                return HTMLResponse("Invalid ISBN", status_code=400)
+            fields["isbn"], fields["isbn10"] = pair
+
+    cover_content = None
     cover_file = form.get("cover")
     if cover_file and hasattr(cover_file, "read"):
         content = await cover_file.read()
         if content and len(content) > 100:
-            cover_path = covers.save_uploaded_cover(item_id, content)
-            if cover_path:
-                fields["cover_path"] = cover_path
+            cover_content = content
 
-    if not fields:
+    if not fields and cover_content is None:
         from fastapi.responses import RedirectResponse
         return RedirectResponse(url=redirect_url, status_code=303)
 
-    set_clause = ", ".join(f"{k} = ?" for k in fields)
-    values = list(fields.values()) + [item_id]
-
     with get_db() as db:
-        old_series_name = None
-        if "series_name" in fields:
-            row = db.execute(
-                "SELECT series_name FROM items WHERE id = ?", (item_id,)
+        current = db.execute(
+            "SELECT series_name FROM items WHERE id = ?", (item_id,)
+        ).fetchone()
+        if not current:
+            return HTMLResponse("Not found", status_code=404)
+
+        if fields.get("location_id") is not None:
+            location = db.execute(
+                "SELECT id FROM locations WHERE id = ?", (fields["location_id"],)
             ).fetchone()
-            old_series_name = row["series_name"] if row else None
+            if not location:
+                return HTMLResponse("Location not found", status_code=400)
 
-        db.execute(
-            f"UPDATE items SET {set_clause}, updated_at = datetime('now') WHERE id = ?",
-            values,
-        )
+        old_series_name = current["series_name"] if "series_name" in fields else None
+        if fields:
+            set_clause = ", ".join(f"{k} = ?" for k in fields)
+            try:
+                db.execute(
+                    f"UPDATE items SET {set_clause}, updated_at = datetime('now') WHERE id = ?",
+                    list(fields.values()) + [item_id],
+                )
+            except sqlite3.IntegrityError:
+                return HTMLResponse(
+                    "Update conflicts with existing catalogue data", status_code=409
+                )
 
-        # Guarded: `fields` only carries series_name when the form submitted it
-        # (a cover-only or partial POST omits it entirely).
-        if "series_name" in fields and old_series_name:
-            new_series_name = fields["series_name"]
-            if old_series_name.strip().casefold() != (new_series_name or "").strip().casefold():
-                gc_orphaned_series_meta(db, old_series_name)
+            if "series_name" in fields and old_series_name:
+                new_series_name = fields["series_name"]
+                if old_series_name.strip().casefold() != (new_series_name or "").strip().casefold():
+                    gc_orphaned_series_meta(db, old_series_name)
+
+    if cover_content is not None:
+        cover_path = covers.save_uploaded_cover(item_id, cover_content)
+        if cover_path:
+            with get_db() as db:
+                db.execute(
+                    "UPDATE items SET cover_path = ?, updated_at = datetime('now') WHERE id = ?",
+                    (cover_path, item_id),
+                )
 
     from fastapi.responses import RedirectResponse
     return RedirectResponse(url=redirect_url, status_code=303)
@@ -894,7 +988,7 @@ async def set_reading_status(request: Request, item_id: int, status: str = Form(
     templates = request.app.state.templates
     valid = ("want_to_read", "reading", "read", "")
     if status not in valid:
-        status = ""
+        return HTMLResponse("Invalid reading status", status_code=400)
 
     reading_status = status or None
     now_date = None
@@ -905,7 +999,6 @@ async def set_reading_status(request: Request, item_id: int, status: str = Form(
             return HTMLResponse("Not found", status_code=404)
 
         updates = {"reading_status": reading_status}
-
         if status == "reading" and not old["date_started"]:
             from datetime import date
             updates["date_started"] = date.today().isoformat()
@@ -915,7 +1008,6 @@ async def set_reading_status(request: Request, item_id: int, status: str = Form(
             updates["date_finished"] = now_date
             if not old["date_started"]:
                 updates["date_started"] = now_date
-            # Log the completed read
             db.execute(
                 "INSERT INTO reading_log (item_id, status, date_started, date_finished) VALUES (?, 'read', ?, ?)",
                 (item_id, old["date_started"], now_date),
@@ -929,20 +1021,13 @@ async def set_reading_status(request: Request, item_id: int, status: str = Form(
             f"UPDATE items SET {set_clause}, updated_at = datetime('now') WHERE id = ?",
             list(updates.values()) + [item_id],
         )
-
         item = db.execute(
             "SELECT i.*, l.name as location_name FROM items i "
             "LEFT JOIN locations l ON i.location_id = l.id WHERE i.id = ?",
             (item_id,),
         ).fetchone()
-
-        # Same connection as the reading_log INSERT above, and after it, so
-        # this read sees its own uncommitted write. The fragment is rendered
-        # from here as well as from pages.item_detail; both must pass the
-        # history or a status toggle swaps in a section whose history vanished.
         reading_history = get_reading_history(db, item_id)
 
-    # Fire-and-forget: push status to Hardcover if linked
     if item["hardcover_user_book_id"]:
         asyncio.create_task(_push_status_to_hardcover(item_id, status))
 
@@ -965,7 +1050,6 @@ async def _push_status_to_hardcover(item_id: int, status: str):
             ).fetchone()
         if not token or not item or not item["hardcover_user_book_id"]:
             return
-
         hc_status_id = hardcover.STATUS_TO_HC.get(status)
         await hardcover.update_user_book(token, item["hardcover_user_book_id"], status_id=hc_status_id)
         logger.debug("Pushed status '%s' to Hardcover for item %d", status, item_id)
@@ -973,25 +1057,11 @@ async def _push_status_to_hardcover(item_id: int, status: str):
         logger.warning("Failed to push status to Hardcover for item %d", item_id, exc_info=True)
 
 
-
-
-
-
-
-
-
-
-
-
-
-
 @router.post("/items/{item_id}/fetch-synopsis")
 async def fetch_synopsis(item_id: int, _=Depends(require_role("editor"))):
     """Look up a description for an item that's missing one."""
     with get_db() as db:
-        item = db.execute(
-            "SELECT isbn, title, authors FROM items WHERE id = ?", (item_id,)
-        ).fetchone()
+        item = db.execute("SELECT isbn, title, authors FROM items WHERE id = ?", (item_id,)).fetchone()
         hc_token = get_setting(db, "hardcover_token")
         google_api_key = get_setting(db, "google_books_api_key")
     if not item:
@@ -1086,43 +1156,16 @@ async def backfill_synopses_stream(request: Request, _=Depends(require_role("adm
 async def delete_item(item_id: int, _=Depends(require_role("editor"))):
     with get_db() as db:
         row = db.execute("SELECT title FROM items WHERE id = ?", (item_id,)).fetchone()
-        title = row["title"] if row else "Item"
-        # Clear scan_log FK (no ON DELETE CASCADE on that table)
+        if not row:
+            return JSONResponse({"ok": False, "message": "Item not found"}, status_code=404)
+        title = row["title"]
         db.execute("UPDATE scan_log SET item_id = NULL WHERE item_id = ?", (item_id,))
-        db.execute("DELETE FROM items WHERE id = ?", (item_id,))
+        cursor = db.execute("DELETE FROM items WHERE id = ?", (item_id,))
+        if cursor.rowcount != 1:
+            return JSONResponse({"ok": False, "message": "Delete failed"}, status_code=409)
     resp = HTMLResponse('{"ok": true}', headers={"Content-Type": "application/json"})
     resp.headers["HX-Trigger"] = items_common._toast_header(f"Deleted: {title[:50]}")
     return resp
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 @router.get("/recent-scans")
@@ -1153,21 +1196,21 @@ async def inventory_missing(
     _=Depends(require_role("editor")),
 ):
     """Find items expected at a location but not scanned during inventory audit."""
-    templates = request.app.state.templates
     scanned = set()
     if scanned_ids.strip():
         scanned = {int(x) for x in scanned_ids.split(",") if x.strip().isdigit()}
 
     with get_db() as db:
         loc = db.execute("SELECT name FROM locations WHERE id = ?", (location_id,)).fetchone()
-        loc_name = loc["name"] if loc else "Unknown"
+        if not loc:
+            return HTMLResponse("Location not found", status_code=404)
+        loc_name = loc["name"]
         items = db.execute(
             "SELECT id, title, authors, cover_path FROM items WHERE location_id = ? ORDER BY title",
             (location_id,),
         ).fetchall()
 
     missing = [dict(i) for i in items if i["id"] not in scanned]
-
     html_parts = []
     if not missing:
         html_parts.append(
@@ -1194,11 +1237,23 @@ async def inventory_missing(
 @router.post("/igdb/test-key")
 async def test_igdb_key(request: Request, _=Depends(require_role("admin"))):
     """Test IGDB (Twitch) credentials."""
-    data = await request.json()
-    client_id = data.get("client_id", "")
-    client_secret = data.get("client_secret", "")
+    try:
+        data = await request.json()
+    except Exception:
+        return {"ok": False, "message": "Invalid request body"}
+    if not isinstance(data, dict):
+        return {"ok": False, "message": "Invalid request body"}
+
+    raw_client_id = data.get("client_id")
+    raw_client_secret = data.get("client_secret")
+    if raw_client_id is not None and not isinstance(raw_client_id, str):
+        return {"ok": False, "message": "Invalid request body"}
+    if raw_client_secret is not None and not isinstance(raw_client_secret, str):
+        return {"ok": False, "message": "Invalid request body"}
+
+    client_id = (raw_client_id or "").strip()
+    client_secret = (raw_client_secret or "").strip()
     if not client_id or not client_secret:
-        # Masked fields post empty — fall back to the stored credentials
         with get_db() as db:
             client_id = client_id or get_setting(db, "igdb_client_id")
             client_secret = client_secret or get_setting(db, "igdb_client_secret")
@@ -1206,8 +1261,3 @@ async def test_igdb_key(request: Request, _=Depends(require_role("admin"))):
         return {"ok": False, "message": "Both Client ID and Client Secret are required"}
     async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
         return await igdb.test_credentials(client_id, client_secret, client)
-
-
-
-
-

--- a/app/routers/items_catalog.py
+++ b/app/routers/items_catalog.py
@@ -21,11 +21,22 @@ from app.services import covers, igdb, openlibrary, scan_outcome, tmdb
 from app.services import isbn as isbn_svc
 from app.services import upc as upc_svc
 from app.services.item_write import insert_item
+from app.services.write_targets import UnknownLocationError, validated_location_id
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api")
 
+_LOCATION_ERROR = "Selected location no longer exists — choose another location"
+
+
+def _location_error(request: Request, templates, isbn: str = ""):
+    """Render the normal scan-card error for a stale location selection."""
+    return templates.TemplateResponse(
+        request,
+        "fragments/scan_result.html",
+        {"status": "error", "isbn": isbn, "message": _LOCATION_ERROR},
+    )
 
 
 @router.get("/games/search")
@@ -67,6 +78,7 @@ async def search_games(
         },
     )
 
+
 @router.post("/games/add")
 async def add_game_from_search(
     request: Request,
@@ -77,6 +89,15 @@ async def add_game_from_search(
 ):
     """Add a video game to the collection from an IGDB search result."""
     templates = request.app.state.templates
+
+    # A location can disappear between rendering the search form and clicking
+    # Add. Reject that target before spending an IGDB request on an insert that
+    # SQLite's foreign key will refuse anyway.
+    try:
+        with get_db() as db:
+            loc_id = validated_location_id(db, location_id)
+    except UnknownLocationError:
+        return _location_error(request, templates)
 
     with get_db() as db:
         client_id = get_setting(db, "igdb_client_id")
@@ -93,8 +114,6 @@ async def add_game_from_search(
             request, "fragments/scan_result.html",
             {"status": "error", "isbn": "", "message": "Failed to fetch game details from IGDB"},
         )
-
-    loc_id = location_id if location_id and location_id > 0 else None
 
     with get_db() as db:
         valid_platforms = get_game_platforms(db)
@@ -149,7 +168,9 @@ async def add_game_from_search(
     resp.headers["HX-Trigger"] = items_common._toast_header(f"Added: {metadata['title'][:50]}")
     return resp
 
+
 BOOK_MEDIA_TYPES = {"book", "kids_book", "audiobook", "ebook", "comic"}
+
 
 @router.get("/title-search")
 async def title_search(
@@ -174,6 +195,7 @@ async def title_search(
     if not items_common.is_valid_media_type(media_type):
         media_type = "book"
     return await search_books(request, q=q, media_type=media_type, _=_)
+
 
 @router.get("/books/search")
 async def search_books(
@@ -205,6 +227,7 @@ async def search_books(
         },
     )
 
+
 @router.post("/books/add")
 async def add_book_from_search(
     request: Request,
@@ -223,12 +246,19 @@ async def add_book_from_search(
             {"status": "error", "isbn": isbn.strip(),
              "message": "Unrecognised media type — pick one and try again"},
         )
-    isbn13 = isbn_svc.to_isbn13(isbn.strip())
-    if not isbn13:
+    pair = isbn_svc.canonical_isbn_pair(isbn.strip())
+    if pair is None:
         return templates.TemplateResponse(
             request, "fragments/scan_result.html",
             {"status": "error", "isbn": isbn, "message": "Invalid ISBN"},
         )
+    isbn13, _isbn10 = pair
+
+    try:
+        with get_db() as db:
+            loc_id = validated_location_id(db, location_id)
+    except UnknownLocationError:
+        return _location_error(request, templates, isbn13)
 
     # Check duplicate
     with get_db() as db:
@@ -261,7 +291,7 @@ async def add_book_from_search(
                 {"status": "error", "isbn": isbn13, "message": "Could not fetch metadata for this ISBN"},
             )
 
-        item_id = items_common._save_item(metadata, isbn13, media_type, location_id, source, hc_ids)
+        item_id = items_common._save_item(metadata, isbn13, media_type, loc_id, source, hc_ids)
 
         hc_cover = metadata.get("cover_url") if source == "hardcover" else hc_ids.get("cover_url")
         cover_path = await covers.download_cover(
@@ -288,6 +318,7 @@ async def add_book_from_search(
     resp.headers["HX-Trigger"] = items_common._toast_header(f"Added: {metadata['title'][:50]}")
     return resp
 
+
 @router.get("/dvds/search")
 async def search_dvds(
     request: Request,
@@ -305,7 +336,7 @@ async def search_dvds(
     if not tmdb_key:
         return HTMLResponse(
             '<p class="text-sm text-shelf-error">TMDb API key not configured. '
-            'Add it in <a href="/settings" class="text-shelf-accent2 underline">Settings</a>.</p>'
+            'Add them in <a href="/settings" class="text-shelf-accent2 underline">Settings</a>.</p>'
         )
 
     async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
@@ -322,6 +353,7 @@ async def search_dvds(
         },
     )
 
+
 @router.post("/dvds/add")
 async def add_dvd_from_search(
     request: Request,
@@ -335,7 +367,12 @@ async def add_dvd_from_search(
 ):
     """Add a DVD/Blu-ray to the collection from a TMDb search result."""
     templates = request.app.state.templates
-    loc_id = location_id if location_id and location_id > 0 else None
+
+    try:
+        with get_db() as db:
+            loc_id = validated_location_id(db, location_id)
+    except UnknownLocationError:
+        return _location_error(request, templates)
 
     # Check duplicate by title
     with get_db() as db:

--- a/app/routers/items_covers.py
+++ b/app/routers/items_covers.py
@@ -179,6 +179,16 @@ async def cover_select(
     _=Depends(require_role("editor")),
 ):
     """Download a selected cover URL and save it for an item."""
+    # The downloader writes directly to the item-id-derived cover path. A
+    # stale link must therefore be rejected before network I/O, otherwise an
+    # unknown id can leave an orphan file and still receive a success redirect.
+    with get_db() as db:
+        item_exists = db.execute(
+            "SELECT 1 FROM items WHERE id = ?", (item_id,)
+        ).fetchone()
+    if not item_exists:
+        return HTMLResponse("Not found", status_code=404)
+
     async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
         cover_path = await covers._download_to_item(item_id, url, client)
 

--- a/app/routers/platforms.py
+++ b/app/routers/platforms.py
@@ -14,15 +14,25 @@ def _slugify(name: str) -> str:
     return re.sub(r"[^a-z0-9]", "", name.lower())
 
 
+def _settings_error(code: str) -> RedirectResponse:
+    return RedirectResponse(url=f"/settings?platform_error={code}", status_code=303)
+
+
 @router.post("")
 async def create_platform(name: str = Form(...)):
     name = name.strip()
     slug = _slugify(name)
-    if not slug:
-        return RedirectResponse(url="/settings", status_code=303)
+    if not name or not slug:
+        return _settings_error("blank")
+
     with get_db() as db:
+        existing = db.execute(
+            "SELECT id FROM game_platforms WHERE slug = ?", (slug,)
+        ).fetchone()
+        if existing:
+            return _settings_error("duplicate")
         db.execute(
-            "INSERT OR IGNORE INTO game_platforms (slug, name) VALUES (?, ?)",
+            "INSERT INTO game_platforms (slug, name) VALUES (?, ?)",
             (slug, name),
         )
     return RedirectResponse(url="/settings", status_code=303)
@@ -32,7 +42,8 @@ async def create_platform(name: str = Form(...)):
 async def delete_platform(platform_id: int):
     with get_db() as db:
         row = db.execute("SELECT slug FROM game_platforms WHERE id = ?", (platform_id,)).fetchone()
-        if row:
-            db.execute("UPDATE items SET platform = NULL WHERE platform = ?", (row["slug"],))
-            db.execute("DELETE FROM game_platforms WHERE id = ?", (platform_id,))
+        if not row:
+            return _settings_error("missing")
+        db.execute("UPDATE items SET platform = NULL WHERE platform = ?", (row["slug"],))
+        db.execute("DELETE FROM game_platforms WHERE id = ?", (platform_id,))
     return RedirectResponse(url="/settings", status_code=303)

--- a/app/services/isbn.py
+++ b/app/services/isbn.py
@@ -14,18 +14,6 @@ def isbn10_to_isbn13(isbn10: str) -> str | None:
     return digits + str(check)
 
 
-def to_isbn13(raw: str) -> str | None:
-    isbn = normalize_isbn(raw)
-    # UPC-A (12 digits) -> EAN-13 by prepending 0
-    if len(isbn) == 12 and isbn.isdigit():
-        isbn = "0" + isbn
-    if len(isbn) == 13 and isbn.isdigit():
-        return isbn
-    if len(isbn) == 10:
-        return isbn10_to_isbn13(isbn)
-    return None
-
-
 def validate_isbn10(s: str) -> bool:
     if not isinstance(s, str) or not s:
         return False
@@ -53,6 +41,25 @@ def validate_isbn13(s: str) -> bool:
     return total % 10 == 0
 
 
+def to_isbn13(raw: str) -> str | None:
+    """Return Shelf's historical 13-digit barcode/ISBN representation.
+
+    This helper is intentionally permissive. It is used by legacy lookup and
+    compatibility paths as well as by ISBN code, so checksum enforcement does
+    not belong here. User-facing ISBN write boundaries must use
+    ``canonical_isbn_pair`` instead.
+    """
+    isbn = normalize_isbn(raw)
+    # UPC-A (12 digits) -> EAN-13 by prepending 0
+    if len(isbn) == 12 and isbn.isdigit():
+        isbn = "0" + isbn
+    if len(isbn) == 13 and isbn.isdigit():
+        return isbn
+    if len(isbn) == 10:
+        return isbn10_to_isbn13(isbn)
+    return None
+
+
 def isbn13_to_isbn10(isbn13: str) -> str | None:
     if len(isbn13) != 13 or not isbn13.startswith("978"):
         return None
@@ -61,3 +68,21 @@ def isbn13_to_isbn10(isbn13: str) -> str | None:
     check = (11 - (total % 11)) % 11
     check_char = "X" if check == 10 else str(check)
     return body + check_char
+
+
+def canonical_isbn_pair(raw: str) -> tuple[str, str | None] | None:
+    """Validate an ISBN and return its canonical ISBN-13/ISBN-10 pair.
+
+    This is for persistence boundaries where the value is known to be an
+    ISBN, not a generic retail barcode. A 979 ISBN has no ISBN-10 equivalent,
+    so the second element is ``None``.
+    """
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    isbn = normalize_isbn(raw)
+    if validate_isbn10(isbn):
+        isbn13 = isbn10_to_isbn13(isbn)
+        return (isbn13, isbn) if isbn13 else None
+    if validate_isbn13(isbn):
+        return isbn, isbn13_to_isbn10(isbn)
+    return None

--- a/app/services/write_targets.py
+++ b/app/services/write_targets.py
@@ -1,0 +1,30 @@
+"""Validation helpers for foreign-key-like targets supplied by write requests.
+
+Routes should validate stale/tampered target ids before doing outbound work or
+attempting an INSERT. SQLite's foreign-key exception is the final invariant,
+not a user-facing control-flow mechanism.
+"""
+
+
+class UnknownLocationError(ValueError):
+    """A positive location id was supplied but no such location exists."""
+
+
+def validated_location_id(db, location_id: int | None) -> int | None:
+    """Return a usable location id, or ``None`` for the no-location sentinel.
+
+    Existing forms historically treat zero/negative values as "no location";
+    keep that compatibility. A positive id is different: it represents an
+    explicit selection and must still exist when the mutation reaches the
+    server, otherwise the caller gets ``UnknownLocationError`` rather than a
+    later SQLite ``IntegrityError``.
+    """
+    if location_id is None or location_id <= 0:
+        return None
+    row = db.execute(
+        "SELECT 1 FROM locations WHERE id = ?",
+        (location_id,),
+    ).fetchone()
+    if row is None:
+        raise UnknownLocationError(f"Location {location_id} not found")
+    return location_id

--- a/app/templates/browse.html
+++ b/app/templates/browse.html
@@ -1,12 +1,16 @@
 {% extends "base.html" %}
 {% block title %}Browse — Shelf{% endblock %}
 {% block content %}
-<div x-data="browsePage" data-initial-query="{{ initial_query or '' }}">
+{% set can_select = user and user.role in ('editor', 'admin') %}
+{% set can_bulk_edit = user and user.role == 'admin' %}
+<div x-data="browsePage" data-initial-query="{{ initial_query or '' }}" data-can-select="{{ '1' if can_select else '0' }}">
+    {% if can_select %}
     <!-- Bulk Action Bar -->
     <div x-show="selectMode && selectedIds.length > 0" x-transition
          class="fixed bottom-0 inset-x-0 z-40 bg-shelf-card border-t border-shelf-border py-3 px-4 shadow-lg">
         <div class="max-w-7xl mx-auto flex items-center gap-3 flex-wrap">
             <span class="text-sm text-shelf-muted" x-text="selectedIds.length + ' selected'"></span>
+            {% if can_bulk_edit %}
             <select x-model="bulkLocationVal" class="bg-shelf-bg border border-shelf-border rounded-lg px-2 py-1 text-sm text-shelf-text">
                 <option value="">Move to location...</option>
                 {% for loc in locations %}
@@ -50,9 +54,11 @@
                 <button @click="bulkUpdate({series_name: '__clear__'})"
                         class="px-3 py-1 bg-shelf-bg border border-shelf-border text-shelf-muted rounded-lg text-xs hover:text-shelf-text">Clear</button>
             </div>
+            {% endif %}
             <button @click="bulkDelete()" class="px-3 py-1 bg-shelf-error/20 text-shelf-error rounded-lg text-xs ml-auto">Delete Selected</button>
         </div>
     </div>
+    {% endif %}
 
     <!-- Header + Filters -->
     <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
@@ -74,6 +80,7 @@
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
                 </button>
             </div>
+            {% if can_select %}
             <!-- Select mode -->
             <div class="relative shrink-0">
                 <button @click="toggleSelectMode()"
@@ -86,7 +93,7 @@
                 <!-- First-use tooltip -->
                 <div x-show="showSelectTip" x-transition
                      class="absolute top-full left-0 mt-2 w-48 bg-shelf-card border border-shelf-border rounded-lg p-2 shadow-xl z-50 text-xs text-shelf-muted">
-                    Tap items to select them for bulk move, type change, status update, or delete.
+                    {% if can_bulk_edit %}Tap items to bulk edit or delete them.{% else %}Tap items to delete them in bulk.{% endif %}
                 </div>
             </div>
             <template x-if="selectMode">
@@ -95,6 +102,7 @@
                     <button @click="deselectAll()" x-show="selectedIds.length > 0" class="px-2 py-1 rounded text-xs text-shelf-muted hover:text-shelf-accent2 transition-colors">Deselect All</button>
                 </div>
             </template>
+            {% endif %}
             <!-- Column picker (list view only) -->
             <div class="relative shrink-0" x-show="viewMode === 'list'">
                 <button @click="columnsOpen = !columnsOpen"

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -4,6 +4,34 @@
 <div class="max-w-2xl mx-auto" x-data="settingsTabs">
     <h1 class="text-2xl font-bold mb-6">Settings</h1>
 
+    {% set platform_error = request.query_params.get('platform_error') %}
+    {% if platform_error in ('blank', 'duplicate', 'missing') %}
+    <div data-testid="platform-error-banner"
+         class="bg-shelf-bg text-shelf-error border border-shelf-border rounded-lg px-4 py-2 text-sm mb-6">
+        {% if platform_error == 'blank' %}
+        Platform name is required.
+        {% elif platform_error == 'duplicate' %}
+        A platform with that name or identifier already exists.
+        {% else %}
+        That platform no longer exists.
+        {% endif %}
+    </div>
+    {% endif %}
+
+    {% set borrower_error = request.query_params.get('borrower_error') %}
+    {% if borrower_error in ('blank', 'duplicate', 'missing') %}
+    <div data-testid="borrower-mutation-error-banner"
+         class="bg-shelf-bg text-shelf-error border border-shelf-border rounded-lg px-4 py-2 text-sm mb-6">
+        {% if borrower_error == 'blank' %}
+        Borrower name is required.
+        {% elif borrower_error == 'duplicate' %}
+        A borrower with that name already exists.
+        {% else %}
+        That borrower no longer exists.
+        {% endif %}
+    </div>
+    {% endif %}
+
     <!-- Tab Bar -->
     <div class="flex gap-1 mb-6 border-b border-shelf-border">
         <button @click="setTab('library')" data-testid="tab-library"

--- a/static/js/browse.js
+++ b/static/js/browse.js
@@ -2,6 +2,7 @@ function browsePage() {
     return {
         selectMode: false,
         selectedIds: [],
+        canSelect: false,
         showSelectTip: false,
         bulkLocationVal: '',
         bulkTypeVal: '',
@@ -33,6 +34,7 @@ function browsePage() {
             // first rather than being populated lazily.
             this.visibleCols = this.loadColumns();
             this.searchQuery = this.$el.dataset.initialQuery || '';
+            this.canSelect = this.$el.dataset.canSelect === '1';
             // Returning to a bare /browse re-applies the last filter set.
             // Falls through to the sort-only restore when there's nothing stored
             // (sessionStorage is per-tab, so a new tab always lands here).
@@ -111,9 +113,8 @@ function browsePage() {
             }
             if (e.key === 'Escape') {
                 if (this.selectMode) { this.selectMode = false; this.selectedIds = []; e.preventDefault(); }
-            } else if (e.key === 'e') {
-                this.selectMode = !this.selectMode;
-                if (!this.selectMode) this.selectedIds = [];
+            } else if (e.key === 'e' && this.canSelect) {
+                this.toggleSelectMode();
                 e.preventDefault();
             } else if (e.key === 'g') {
                 this.setView(this.viewMode === 'grid' ? 'list' : 'grid');
@@ -386,6 +387,7 @@ function browsePage() {
         },
 
         toggleSelectMode() {
+            if (!this.canSelect) return;
             this.selectMode = !this.selectMode;
             if (!this.selectMode) this.selectedIds = [];
             localStorage.setItem('shelf-select-used', '1');
@@ -423,6 +425,13 @@ function browsePage() {
             this.selectedIds = [];
         },
 
+        // Alpine's CSP evaluator has no access to browser globals, so the
+        // template's bare parseInt(...) call must resolve on component scope.
+        // Keep the conversion here rather than weakening script-src.
+        parseInt(value) {
+            return Number.parseInt(value, 10);
+        },
+
         async bulkUpdate(updates) {
             if (!this.selectedIds.length) return;
             try {
@@ -445,13 +454,38 @@ function browsePage() {
         },
 
         async bulkDelete() {
-            if (!confirm('Delete ' + this.selectedIds.length + ' items?')) return;
-            for (var id of this.selectedIds) {
-                await fetch('/api/items/' + id, {method: 'DELETE', headers: {'X-CSRF-Token': window.csrfToken()}});
+            var ids = this.selectedIds.slice();
+            if (!ids.length || !confirm('Delete ' + ids.length + ' items?')) return;
+
+            var deleted = 0;
+            var failed = 0;
+            for (var id of ids) {
+                try {
+                    var resp = await fetch('/api/items/' + id, {
+                        method: 'DELETE',
+                        headers: {'X-CSRF-Token': window.csrfToken()}
+                    });
+                    if (resp.ok) deleted += 1;
+                    else failed += 1;
+                } catch (e) {
+                    failed += 1;
+                }
             }
-            showToast('Deleted ' + this.selectedIds.length + ' items', 'success');
-            this.selectedIds = [];
-            location.reload();
+
+            if (failed === 0) {
+                showToast('Deleted ' + deleted + ' items', 'success');
+                this.selectedIds = [];
+                location.reload();
+                return;
+            }
+
+            if (deleted > 0) {
+                showToast('Deleted ' + deleted + ' items; ' + failed + ' failed', 'error');
+                this.selectedIds = [];
+                location.reload();
+            } else {
+                showToast('Delete failed for ' + failed + ' items', 'error');
+            }
         }
     }
 }

--- a/static/js/item_edit.js
+++ b/static/js/item_edit.js
@@ -19,6 +19,20 @@ function coverDrop() {
     }
 }
 
+// Existing libraries can contain ISBN-shaped identifiers written by older
+// Shelf versions before checksum validation existed. Do not resubmit an
+// unchanged ISBN when saving an unrelated edit: the server only needs to
+// validate the identifier when the user actually changes it. Disabling the
+// unchanged field at submit time keeps legacy rows editable without weakening
+// validation for new values (disabled controls are not included in form data).
+document.addEventListener('DOMContentLoaded', function () {
+    var isbn = document.getElementById('isbn');
+    if (!isbn || !isbn.form) return;
+    isbn.form.addEventListener('submit', function () {
+        if (isbn.value === isbn.defaultValue) isbn.disabled = true;
+    });
+});
+
 // CSP build has no global fallback — register so x-data="coverDrop" resolves.
 document.addEventListener('alpine:init', function () {
     Alpine.data('coverDrop', coverDrop);

--- a/tests/e2e/test_bulk_actions.py
+++ b/tests/e2e/test_bulk_actions.py
@@ -1,0 +1,93 @@
+"""E2E coverage for user-facing controls that previously had no browser test.
+
+These tests drive the actual Alpine/HTMX/CSP UI rather than calling API
+endpoints directly.  That distinction is important: an endpoint can be correct
+while a client-side expression prevents the button from ever sending a request.
+"""
+import sqlite3
+
+import pytest
+from playwright.sync_api import expect
+
+from tests.e2e.conftest import insert_item
+
+pytestmark = pytest.mark.e2e
+
+
+def _insert_location(data_dir, name: str) -> int:
+    conn = sqlite3.connect(str(data_dir / "shelf.db"))
+    try:
+        cur = conn.execute("INSERT INTO locations (name) VALUES (?)", (name,))
+        conn.commit()
+        return cur.lastrowid
+    finally:
+        conn.close()
+
+
+def _location_id(data_dir, item_id: int):
+    conn = sqlite3.connect(str(data_dir / "shelf.db"))
+    try:
+        row = conn.execute("SELECT location_id FROM items WHERE id = ?", (item_id,)).fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+def test_bulk_move_apply_moves_selected_list_item(live_server, authed_page):
+    """Selecting a list row, choosing a location and pressing Apply must move it.
+
+    This is deliberately a browser test.  The bulk-update API already has unit
+    coverage, but that did not catch a dead Alpine click expression in the UI.
+    """
+    location_id = _insert_location(live_server["data_dir"], "Bulk Move Target")
+    item_id = insert_item(
+        live_server["data_dir"],
+        title="Bulk Move Browser Probe",
+        isbn="9780000999401",
+    )
+
+    authed_page.goto(f"{live_server['url']}/browse")
+    authed_page.wait_for_load_state("networkidle")
+    authed_page.locator("[data-testid='view-list']").click()
+    expect(authed_page.locator(f"tr[data-item-id='{item_id}']")).to_be_visible()
+
+    authed_page.get_by_role("button", name="Select", exact=True).click()
+    authed_page.locator(f"tr[data-item-id='{item_id}']").click()
+    expect(authed_page.get_by_text("1 selected", exact=True)).to_be_visible()
+
+    authed_page.locator('select[x-model="bulkLocationVal"]').select_option(str(location_id))
+    apply_button = authed_page.get_by_role("button", name="Apply", exact=True).first
+    expect(apply_button).to_be_visible()
+
+    # bulkUpdate() awaits its POST before calling location.reload().  Waiting
+    # for the current page's load state after click is racy because it may
+    # already be network-idle before that future reload starts.  Arm the
+    # navigation waiter first so the assertion always observes the completed
+    # mutation rather than whichever side of that race the runner happened to
+    # hit.
+    with authed_page.expect_navigation(wait_until="networkidle"):
+        apply_button.click()
+
+    assert _location_id(live_server["data_dir"], item_id) == location_id
+
+
+def test_shortcut_help_button_opens_and_modal_controls_close(live_server, authed_page):
+    """The visible ? button and modal close surfaces must work under strict CSP."""
+    authed_page.goto(f"{live_server['url']}/browse")
+    authed_page.wait_for_load_state("networkidle")
+
+    modal = authed_page.locator("#shortcut-modal")
+    expect(modal).to_be_hidden()
+
+    authed_page.get_by_title("Keyboard shortcuts (?)").click()
+    expect(modal).to_be_visible()
+
+    # The modal header has a single close button.
+    modal.locator("button").first.click()
+    expect(modal).to_be_hidden()
+
+    # Reopen and verify clicking the backdrop closes it too.
+    authed_page.get_by_title("Keyboard shortcuts (?)").click()
+    expect(modal).to_be_visible()
+    modal.click(position={"x": 5, "y": 5})
+    expect(modal).to_be_hidden()

--- a/tests/e2e/test_bulk_delete_failures.py
+++ b/tests/e2e/test_bulk_delete_failures.py
@@ -1,0 +1,40 @@
+"""Browser regressions for Browse bulk-delete error handling."""
+
+import pytest
+from playwright.sync_api import expect
+
+from tests.e2e.conftest import insert_item
+
+pytestmark = pytest.mark.e2e
+
+
+def test_bulk_delete_failure_is_not_reported_as_success(live_server, authed_page):
+    item_id = insert_item(
+        live_server["data_dir"],
+        title="Bulk Delete Failure Probe",
+        isbn="9780000999418",
+    )
+
+    authed_page.goto(f"{live_server['url']}/browse")
+    authed_page.wait_for_load_state("networkidle")
+
+    authed_page.get_by_role("button", name="Select", exact=True).click()
+    card = authed_page.locator(f"[data-item-id='{item_id}']").first
+    expect(card).to_be_visible()
+    card.click()
+    expect(authed_page.get_by_text("1 selected", exact=True)).to_be_visible()
+
+    authed_page.route(
+        f"**/api/items/{item_id}",
+        lambda route: route.fulfill(
+            status=500,
+            content_type="application/json",
+            body='{"ok": false, "message": "forced failure"}',
+        ),
+    )
+    authed_page.once("dialog", lambda dialog: dialog.accept())
+    authed_page.get_by_role("button", name="Delete Selected", exact=True).click()
+
+    expect(authed_page.get_by_text("Delete failed for 1 items", exact=True)).to_be_visible()
+    expect(authed_page.locator(f"[data-item-id='{item_id}']").first).to_be_visible()
+    expect(authed_page.get_by_text("1 selected", exact=True)).to_be_visible()

--- a/tests/test_browse_permissions.py
+++ b/tests/test_browse_permissions.py
@@ -1,0 +1,39 @@
+"""Role-aware Browse bulk-action rendering."""
+
+
+def test_viewer_has_no_bulk_selection_controls(viewer_client):
+    response = viewer_client.get("/browse")
+    assert response.status_code == 200
+    html = response.text
+
+    assert 'data-can-select="0"' in html
+    assert "Delete Selected" not in html
+    assert "Move to location..." not in html
+    assert 'x-model="bulkTypeVal"' not in html
+    assert 'id="bulk-series"' not in html
+
+
+def test_editor_can_bulk_delete_but_not_bulk_edit(editor_client):
+    response = editor_client.get("/browse")
+    assert response.status_code == 200
+    html = response.text
+
+    assert 'data-can-select="1"' in html
+    assert "Delete Selected" in html
+    assert "Move to location..." not in html
+    assert 'x-model="bulkTypeVal"' not in html
+    assert 'id="bulk-series"' not in html
+    assert "Tap items to delete them in bulk." in html
+
+
+def test_admin_gets_bulk_edit_and_delete_controls(admin_client):
+    response = admin_client.get("/browse")
+    assert response.status_code == 200
+    html = response.text
+
+    assert 'data-can-select="1"' in html
+    assert "Delete Selected" in html
+    assert "Move to location..." in html
+    assert 'x-model="bulkTypeVal"' in html
+    assert 'id="bulk-series"' in html
+    assert "Tap items to bulk edit or delete them." in html

--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -1,0 +1,180 @@
+"""Regression tests for user-facing catalogue write integrity."""
+
+from app.database import get_db
+from tests.conftest import _insert_item
+
+
+BAD_ISBN13 = "9780441172710"  # valid shape, deliberately wrong checksum
+
+
+def test_scan_rejects_bad_isbn_checksum_before_lookup(admin_client, db):
+    resp = admin_client.post(
+        "/api/scan",
+        data={"isbn": BAD_ISBN13, "media_type": "book", "mode": "add"},
+    )
+    assert resp.status_code == 200
+    assert b"Invalid ISBN" in resp.content
+    with get_db() as check_db:
+        assert check_db.execute(
+            "SELECT 1 FROM items WHERE isbn = ?", (BAD_ISBN13,)
+        ).fetchone() is None
+
+
+def test_catalogue_add_rejects_bad_isbn_checksum_before_lookup(admin_client, db):
+    resp = admin_client.post(
+        "/api/books/add",
+        data={"isbn": BAD_ISBN13, "media_type": "book"},
+    )
+    assert resp.status_code == 200
+    assert b"Invalid ISBN" in resp.content
+    with get_db() as check_db:
+        assert check_db.execute(
+            "SELECT 1 FROM items WHERE isbn = ?", (BAD_ISBN13,)
+        ).fetchone() is None
+
+
+def test_manual_add_rejects_bad_isbn_instead_of_dropping_it(admin_client, db):
+    resp = admin_client.post(
+        "/api/items/manual",
+        data={"title": "Bad ISBN Manual Probe", "isbn": BAD_ISBN13, "media_type": "book"},
+    )
+    assert resp.status_code == 200
+    assert b"Invalid ISBN" in resp.content
+    with get_db() as check_db:
+        assert check_db.execute(
+            "SELECT 1 FROM items WHERE title = ?", ("Bad ISBN Manual Probe",)
+        ).fetchone() is None
+
+
+def test_edit_isbn10_canonicalises_and_synchronises_pair(admin_client, db):
+    item_id = _insert_item(
+        db,
+        title="ISBN Edit Probe",
+        isbn="9780441172719",
+        isbn10="0441172717",
+    )
+    db.commit()
+
+    resp = admin_client.post(
+        f"/api/items/{item_id}",
+        data={"isbn": "054792822X"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    with get_db() as check_db:
+        row = check_db.execute(
+            "SELECT isbn, isbn10 FROM items WHERE id = ?", (item_id,)
+        ).fetchone()
+    assert row["isbn"] == "9780547928227"
+    assert row["isbn10"] == "054792822X"
+
+
+def test_edit_bad_isbn_preserves_existing_pair(admin_client, db):
+    item_id = _insert_item(
+        db,
+        title="ISBN Reject Probe",
+        isbn="9780441172719",
+        isbn10="0441172717",
+    )
+    db.commit()
+
+    resp = admin_client.post(
+        f"/api/items/{item_id}",
+        data={"isbn": BAD_ISBN13},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    assert b"Invalid ISBN" in resp.content
+
+    with get_db() as check_db:
+        row = check_db.execute(
+            "SELECT isbn, isbn10 FROM items WHERE id = ?", (item_id,)
+        ).fetchone()
+    assert row["isbn"] == "9780441172719"
+    assert row["isbn10"] == "0441172717"
+
+
+def test_edit_nonexistent_item_returns_not_found(admin_client):
+    resp = admin_client.post(
+        "/api/items/999999999",
+        data={"title": "Nowhere"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 404
+    assert resp.text == "Not found"
+
+
+def test_bulk_clear_reading_status_stores_null(admin_client, db):
+    item_id = _insert_item(
+        db,
+        title="Bulk Status Probe",
+        isbn="9780000000290",
+        reading_status="reading",
+    )
+    db.commit()
+
+    resp = admin_client.post(
+        "/api/items/bulk-update",
+        json={"item_ids": [item_id], "updates": {"reading_status": ""}},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "updated": 1}
+
+    with get_db() as check_db:
+        row = check_db.execute(
+            "SELECT reading_status FROM items WHERE id = ?", (item_id,)
+        ).fetchone()
+    assert row["reading_status"] is None
+
+
+def test_bulk_invalid_reading_status_is_rejected_without_mutation(admin_client, db):
+    item_id = _insert_item(
+        db,
+        title="Bulk Invalid Status Probe",
+        isbn="9780000000292",
+        reading_status="reading",
+    )
+    db.commit()
+
+    resp = admin_client.post(
+        "/api/items/bulk-update",
+        json={"item_ids": [item_id], "updates": {"reading_status": "finished-ish"}},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": False, "message": "Invalid reading status"}
+
+    with get_db() as check_db:
+        row = check_db.execute(
+            "SELECT reading_status FROM items WHERE id = ?", (item_id,)
+        ).fetchone()
+    assert row["reading_status"] == "reading"
+
+
+def test_bulk_update_reports_rows_that_actually_exist(admin_client, db):
+    item_id = _insert_item(db, title="Bulk Count Probe", isbn="9780000000291")
+    db.commit()
+
+    resp = admin_client.post(
+        "/api/items/bulk-update",
+        json={"item_ids": [item_id, 999999999], "updates": {"owned": 0}},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "updated": 1}
+
+    missing = admin_client.post(
+        "/api/items/bulk-update",
+        json={"item_ids": [999999998], "updates": {"owned": 0}},
+    )
+    assert missing.status_code == 200
+    assert missing.json() == {
+        "ok": False,
+        "message": "No matching items found",
+        "updated": 0,
+    }
+
+
+def test_delete_nonexistent_item_is_not_reported_as_success(admin_client):
+    resp = admin_client.delete("/api/items/999999999")
+    assert resp.status_code == 404
+    assert resp.json() == {"ok": False, "message": "Item not found"}

--- a/tests/test_hardcover_add_request_validation.py
+++ b/tests/test_hardcover_add_request_validation.py
@@ -1,0 +1,65 @@
+"""Request-boundary regressions for adding Hardcover search results."""
+
+
+class _NoOutboundClient:
+    def __init__(self, *args, **kwargs):
+        raise AssertionError("malformed Hardcover add input must not make an outbound request")
+
+
+def _assert_not_inserted(db, title="Forged Hardcover Book"):
+    row = db.execute("SELECT id FROM items WHERE title = ?", (title,)).fetchone()
+    assert row is None
+
+
+def test_hardcover_add_rejects_invalid_json(admin_client, db, monkeypatch):
+    from app.routers import hardcover as hardcover_router
+
+    monkeypatch.setattr(hardcover_router.httpx, "AsyncClient", _NoOutboundClient)
+    response = admin_client.post(
+        "/api/hardcover/add-to-shelf",
+        content="{",
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": False, "message": "Invalid request body"}
+    _assert_not_inserted(db)
+
+
+def test_hardcover_add_rejects_non_object_json(admin_client, db, monkeypatch):
+    from app.routers import hardcover as hardcover_router
+
+    monkeypatch.setattr(hardcover_router.httpx, "AsyncClient", _NoOutboundClient)
+    response = admin_client.post("/api/hardcover/add-to-shelf", json=["book"])
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": False, "message": "Invalid request body"}
+    _assert_not_inserted(db)
+
+
+def test_hardcover_add_rejects_non_string_title(admin_client, db, monkeypatch):
+    from app.routers import hardcover as hardcover_router
+
+    monkeypatch.setattr(hardcover_router.httpx, "AsyncClient", _NoOutboundClient)
+    response = admin_client.post(
+        "/api/hardcover/add-to-shelf",
+        json={"title": 123, "cover_url": "https://example.invalid/cover.jpg"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": False, "message": "Invalid request body"}
+    _assert_not_inserted(db)
+
+
+def test_hardcover_add_rejects_non_string_cover_before_insert(admin_client, db, monkeypatch):
+    from app.routers import hardcover as hardcover_router
+
+    monkeypatch.setattr(hardcover_router.httpx, "AsyncClient", _NoOutboundClient)
+    response = admin_client.post(
+        "/api/hardcover/add-to-shelf",
+        json={"title": "Forged Hardcover Book", "cover_url": {"url": "https://example.invalid/cover.jpg"}},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": False, "message": "Invalid request body"}
+    _assert_not_inserted(db)

--- a/tests/test_hardcover_schedule_validation.py
+++ b/tests/test_hardcover_schedule_validation.py
@@ -1,0 +1,23 @@
+"""Regression coverage for Hardcover schedule mutation boundaries."""
+
+
+def test_hardcover_schedule_rejects_invalid_interval_without_disabling_sync(
+    admin_client, db
+):
+    db.execute(
+        "INSERT INTO settings (key, value) VALUES ('hc_sync_interval', 'daily')"
+    )
+    db.commit()
+
+    response = admin_client.post(
+        "/api/hardcover/schedule",
+        data={"interval": "hourly"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"ok": False, "message": "Invalid sync interval"}
+    stored = db.execute(
+        "SELECT value FROM settings WHERE key = 'hc_sync_interval'"
+    ).fetchone()["value"]
+    assert stored == "daily"

--- a/tests/test_hardcover_test_request_validation.py
+++ b/tests/test_hardcover_test_request_validation.py
@@ -1,0 +1,47 @@
+"""Request-boundary regressions for the Hardcover credential test."""
+
+from unittest.mock import AsyncMock
+
+from app.services import hardcover
+
+
+def _fail_if_called(monkeypatch):
+    stub = AsyncMock(side_effect=AssertionError(
+        "malformed Hardcover test input must not make an outbound request"
+    ))
+    monkeypatch.setattr(hardcover, "test_connection", stub)
+    return stub
+
+
+def test_hardcover_test_rejects_non_object_json(admin_client, monkeypatch):
+    stub = _fail_if_called(monkeypatch)
+
+    response = admin_client.post("/api/hardcover/test", json=["token"])
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": False, "message": "Invalid request body"}
+    stub.assert_not_awaited()
+
+
+def test_hardcover_test_rejects_non_string_token(admin_client, monkeypatch):
+    stub = _fail_if_called(monkeypatch)
+
+    response = admin_client.post("/api/hardcover/test", json={"token": 123})
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": False, "message": "Invalid request body"}
+    stub.assert_not_awaited()
+
+
+def test_hardcover_test_rejects_invalid_json(admin_client, monkeypatch):
+    stub = _fail_if_called(monkeypatch)
+
+    response = admin_client.post(
+        "/api/hardcover/test",
+        content="{",
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": False, "message": "Invalid request body"}
+    stub.assert_not_awaited()

--- a/tests/test_igdb_test_request_validation.py
+++ b/tests/test_igdb_test_request_validation.py
@@ -1,0 +1,82 @@
+"""Request-shape regressions for the IGDB credential test endpoint."""
+
+from unittest.mock import AsyncMock
+
+from app.routers import items
+
+
+class _NoOutboundClient:
+    def __init__(self, *args, **kwargs):
+        raise AssertionError("outbound client must not be created for invalid input")
+
+
+class _FakeAsyncClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+def test_invalid_json_is_rejected_before_outbound(admin_client, monkeypatch):
+    monkeypatch.setattr(items.httpx, "AsyncClient", _NoOutboundClient)
+
+    response = admin_client.post(
+        "/api/igdb/test-key",
+        content=b"{",
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.json() == {"ok": False, "message": "Invalid request body"}
+
+
+def test_non_object_json_is_rejected_before_outbound(admin_client, monkeypatch):
+    monkeypatch.setattr(items.httpx, "AsyncClient", _NoOutboundClient)
+
+    response = admin_client.post("/api/igdb/test-key", json=[])
+
+    assert response.json() == {"ok": False, "message": "Invalid request body"}
+
+
+def test_non_string_client_id_is_rejected_before_fallback(admin_client, monkeypatch):
+    monkeypatch.setenv("IGDB_CLIENT_ID", "env-client")
+    monkeypatch.setenv("IGDB_CLIENT_SECRET", "env-secret")
+    monkeypatch.setattr(items.httpx, "AsyncClient", _NoOutboundClient)
+
+    response = admin_client.post(
+        "/api/igdb/test-key", json={"client_id": 123, "client_secret": ""}
+    )
+
+    assert response.json() == {"ok": False, "message": "Invalid request body"}
+
+
+def test_non_string_client_secret_is_rejected_before_fallback(admin_client, monkeypatch):
+    monkeypatch.setenv("IGDB_CLIENT_ID", "env-client")
+    monkeypatch.setenv("IGDB_CLIENT_SECRET", "env-secret")
+    monkeypatch.setattr(items.httpx, "AsyncClient", _NoOutboundClient)
+
+    response = admin_client.post(
+        "/api/igdb/test-key", json={"client_id": "", "client_secret": 123}
+    )
+
+    assert response.json() == {"ok": False, "message": "Invalid request body"}
+
+
+def test_blank_fields_preserve_env_only_fallback(admin_client, monkeypatch):
+    monkeypatch.setenv("IGDB_CLIENT_ID", "env-client")
+    monkeypatch.setenv("IGDB_CLIENT_SECRET", "env-secret")
+    monkeypatch.setattr(items.httpx, "AsyncClient", _FakeAsyncClient)
+    stub = AsyncMock(return_value={"ok": True, "message": "Connected"})
+    monkeypatch.setattr(items.igdb, "test_credentials", stub)
+
+    response = admin_client.post(
+        "/api/igdb/test-key", json={"client_id": "", "client_secret": ""}
+    )
+
+    assert response.json()["ok"] is True
+    assert stub.await_count == 1
+    assert stub.await_args.args[0] == "env-client"
+    assert stub.await_args.args[1] == "env-secret"

--- a/tests/test_isbn.py
+++ b/tests/test_isbn.py
@@ -9,6 +9,7 @@ from app.services.isbn import (
     isbn13_to_isbn10,
     validate_isbn10,
     validate_isbn13,
+    canonical_isbn_pair,
 )
 from app.services.upc import normalize_barcode, detect_barcode_type, validate_upc
 
@@ -35,7 +36,6 @@ class TestIsbn10ToIsbn13:
         assert isbn10_to_isbn13("123") is None
 
     def test_the_hobbit(self):
-        # The Hobbit: ISBN-10 054792822X -> ISBN-13 9780547928227
         assert isbn10_to_isbn13("054792822X") == "9780547928227"
 
 
@@ -51,7 +51,6 @@ class TestIsbn13ToIsbn10:
         assert isbn13_to_isbn10("978") is None
 
     def test_check_digit_x(self):
-        # ISBN-13 9780074625422 -> ISBN-10 007462542X (check digit is X)
         result = isbn13_to_isbn10("9780074625422")
         assert result == "007462542X"
 
@@ -67,8 +66,10 @@ class TestToIsbn13:
         assert to_isbn13("978-0-13-468599-1") == "9780134685991"
 
     def test_upc_12_digit_prepends_zero(self):
-        # 12-digit UPC -> 13-digit EAN
         assert to_isbn13("012345678905") == "0012345678905"
+
+    def test_non_isbn_ean13_keeps_legacy_passthrough(self):
+        assert to_isbn13("4006381333931") == "4006381333931"
 
     def test_invalid_returns_none(self):
         assert to_isbn13("invalid") is None
@@ -133,6 +134,31 @@ class TestValidateIsbn13:
 
     def test_non_string_returns_false(self):
         assert validate_isbn13(123) is False
+
+
+class TestCanonicalIsbnPair:
+    def test_isbn10_returns_matching_pair(self):
+        assert canonical_isbn_pair("054792822X") == ("9780547928227", "054792822X")
+
+    def test_isbn13_returns_matching_isbn10(self):
+        assert canonical_isbn_pair("9780441172719") == ("9780441172719", "0441172717")
+
+    def test_979_has_no_isbn10_equivalent(self):
+        assert canonical_isbn_pair("9791234567896") == ("9791234567896", None)
+
+    def test_normalizes_formatting(self):
+        assert canonical_isbn_pair("978-0-54-792822-7") == ("9780547928227", "054792822X")
+
+    def test_rejects_bad_checksum(self):
+        assert canonical_isbn_pair("9780441172710") is None
+        assert canonical_isbn_pair("0441172718") is None
+
+    def test_rejects_upc_even_though_legacy_converter_accepts_it(self):
+        assert canonical_isbn_pair("012345678905") is None
+
+    def test_blank_or_non_string_is_invalid(self):
+        assert canonical_isbn_pair("") is None
+        assert canonical_isbn_pair(None) is None
 
 
 # --- UPC ---

--- a/tests/test_item_edit_boundaries.py
+++ b/tests/test_item_edit_boundaries.py
@@ -1,0 +1,158 @@
+"""Request-boundary regressions for single-item edit and quick status writes."""
+
+from app.routers import items
+from tests.conftest import _insert_item
+
+
+def _row(db, item_id):
+    return db.execute("SELECT * FROM items WHERE id = ?", (item_id,)).fetchone()
+
+
+def _forbid_cover_save(*args, **kwargs):
+    raise AssertionError("cover storage must not run for a rejected edit")
+
+
+def test_edit_rejects_blank_title_without_mutation(editor_client, db):
+    item_id = _insert_item(db, title="Keep Title", isbn="9780441172719")
+    db.commit()
+
+    response = editor_client.post(f"/api/items/{item_id}", data={"title": ""})
+
+    assert response.status_code == 400
+    assert response.text == "Title is required"
+    assert _row(db, item_id)["title"] == "Keep Title"
+
+
+def test_edit_rejects_malformed_integer_without_mutation(editor_client, db):
+    item_id = _insert_item(db, title="Keep Year", isbn="9780441172719", publish_year=1965)
+    db.commit()
+
+    response = editor_client.post(
+        f"/api/items/{item_id}", data={"publish_year": "nineteen-sixty-five"}
+    )
+
+    assert response.status_code == 400
+    assert response.text == "Invalid publish year"
+    assert _row(db, item_id)["publish_year"] == 1965
+
+
+def test_edit_rejects_malformed_float_without_mutation(editor_client, db):
+    item_id = _insert_item(db, title="Keep Value", isbn="9780441172719", manual_value=12.5)
+    db.commit()
+
+    response = editor_client.post(
+        f"/api/items/{item_id}", data={"manual_value": "twelve-pounds"}
+    )
+
+    assert response.status_code == 400
+    assert response.text == "Invalid manual value"
+    assert _row(db, item_id)["manual_value"] == 12.5
+
+
+def test_edit_rejects_unknown_media_type_without_mutation(editor_client, db):
+    item_id = _insert_item(db, title="Keep Type", isbn="9780441172719", media_type="book")
+    db.commit()
+
+    response = editor_client.post(
+        f"/api/items/{item_id}", data={"media_type": "vinyl"}
+    )
+
+    assert response.status_code == 400
+    assert response.text == "Invalid media type"
+    assert _row(db, item_id)["media_type"] == "book"
+
+
+def test_edit_rejects_unknown_reading_status_without_mutation(editor_client, db):
+    item_id = _insert_item(
+        db, title="Keep Status", isbn="9780441172719", reading_status="reading"
+    )
+    db.commit()
+
+    response = editor_client.post(
+        f"/api/items/{item_id}", data={"reading_status": "abandoned"}
+    )
+
+    assert response.status_code == 400
+    assert response.text == "Invalid reading status"
+    assert _row(db, item_id)["reading_status"] == "reading"
+
+
+def test_edit_rejects_invalid_owned_value_without_mutation(editor_client, db):
+    item_id = _insert_item(db, title="Keep Owned", isbn="9780441172719", owned=1)
+    db.commit()
+
+    response = editor_client.post(f"/api/items/{item_id}", data={"owned": "2"})
+
+    assert response.status_code == 400
+    assert response.text == "Owned must be 0 or 1"
+    assert _row(db, item_id)["owned"] == 1
+
+
+def test_edit_rejects_stale_location_before_cover_storage(editor_client, db, monkeypatch):
+    item_id = _insert_item(db, title="Keep Location", isbn="9780441172719")
+    db.commit()
+    monkeypatch.setattr(items.covers, "save_uploaded_cover", _forbid_cover_save)
+
+    response = editor_client.post(
+        f"/api/items/{item_id}",
+        data={"location_id": "999999"},
+        files={"cover": ("cover.jpg", b"x" * 200, "image/jpeg")},
+    )
+
+    assert response.status_code == 400
+    assert response.text == "Location not found"
+    assert _row(db, item_id)["location_id"] is None
+
+
+def test_edit_missing_item_rejected_before_cover_storage(editor_client, monkeypatch):
+    monkeypatch.setattr(items.covers, "save_uploaded_cover", _forbid_cover_save)
+
+    response = editor_client.post(
+        "/api/items/999999",
+        files={"cover": ("cover.jpg", b"x" * 200, "image/jpeg")},
+    )
+
+    assert response.status_code == 404
+    assert response.text == "Not found"
+
+
+def test_edit_catalogue_conflict_rejected_before_cover_storage(editor_client, db, monkeypatch):
+    keep_id = _insert_item(db, title="Existing ISBN", isbn="9780441172719", media_type="book")
+    edit_id = _insert_item(db, title="Edited ISBN", isbn="9780156027601", media_type="book")
+    db.commit()
+    monkeypatch.setattr(items.covers, "save_uploaded_cover", _forbid_cover_save)
+
+    response = editor_client.post(
+        f"/api/items/{edit_id}",
+        data={"isbn": "9780441172719"},
+        files={"cover": ("cover.jpg", b"x" * 200, "image/jpeg")},
+    )
+
+    assert response.status_code == 409
+    assert response.text == "Update conflicts with existing catalogue data"
+    assert _row(db, keep_id)["isbn"] == "9780441172719"
+    assert _row(db, edit_id)["isbn"] == "9780156027601"
+
+
+def test_quick_status_rejects_unknown_value_without_clearing(editor_client, db):
+    item_id = _insert_item(db, title="Keep Quick Status", isbn="9780441172719")
+    db.execute(
+        "UPDATE items SET reading_status = 'read', date_started = '2026-01-01', "
+        "date_finished = '2026-01-02' WHERE id = ?",
+        (item_id,),
+    )
+    db.commit()
+
+    response = editor_client.post(
+        f"/api/items/{item_id}/reading-status", data={"status": "abandoned"}
+    )
+
+    assert response.status_code == 400
+    assert response.text == "Invalid reading status"
+    row = _row(db, item_id)
+    assert row["reading_status"] == "read"
+    assert row["date_started"] == "2026-01-01"
+    assert row["date_finished"] == "2026-01-02"
+    assert db.execute(
+        "SELECT COUNT(*) FROM reading_log WHERE item_id = ?", (item_id,)
+    ).fetchone()[0] == 0

--- a/tests/test_lending_boundaries.py
+++ b/tests/test_lending_boundaries.py
@@ -1,0 +1,110 @@
+"""Regression coverage for borrower feedback and serialized checkout creation."""
+
+import sqlite3
+from contextlib import contextmanager
+
+from tests.conftest import _insert_borrower, _insert_item
+
+
+def test_blank_borrower_preserves_bad_request_contract(admin_client, db):
+    response = admin_client.post(
+        "/api/borrowers",
+        data={"name": "   "},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["ok"] is False
+    assert db.execute("SELECT COUNT(*) FROM borrowers").fetchone()[0] == 0
+
+
+def test_duplicate_borrower_is_reported_instead_of_silently_ignored(admin_client, db):
+    _insert_borrower(db, "Alice")
+    db.commit()
+
+    response = admin_client.post(
+        "/api/borrowers",
+        data={"name": "Alice"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/settings?borrower_error=duplicate"
+    assert db.execute(
+        "SELECT COUNT(*) FROM borrowers WHERE name = 'Alice'"
+    ).fetchone()[0] == 1
+
+
+def test_delete_missing_borrower_is_reported(admin_client):
+    response = admin_client.post(
+        "/api/borrowers/999999/delete",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/settings?borrower_error=missing"
+
+
+def test_borrower_mutation_banner_never_reflects_unknown_code(admin_client):
+    known = admin_client.get("/settings?borrower_error=duplicate")
+    assert 'data-testid="borrower-mutation-error-banner"' in known.text
+    assert "A borrower with that name already exists." in known.text
+
+    unknown = admin_client.get(
+        "/settings?borrower_error=%3Cscript%3Ealert(1)%3C%2Fscript%3E"
+    )
+    assert 'data-testid="borrower-mutation-error-banner"' not in unknown.text
+    assert "alert(1)" not in unknown.text
+
+
+def test_checkout_active_guard_runs_under_write_lock(admin_client, db, monkeypatch):
+    """A competing checkout writer must be locked out while the guard is read."""
+    import app.config
+    import app.routers.checkouts as checkouts_mod
+
+    item_id = _insert_item(db, title="Serialized Loan", isbn="9780306406157")
+    borrower_id = _insert_borrower(db, "Lock Tester")
+    db.commit()
+
+    probe_results = []
+    real_get_db = checkouts_mod.get_db
+
+    class LockProbingConnection:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+        def execute(self, sql, *args, **kwargs):
+            result = self._conn.execute(sql, *args, **kwargs)
+            if "WHERE item_id = ? AND checked_in IS NULL" in sql:
+                rival = sqlite3.connect(str(app.config.DATABASE_PATH), timeout=0)
+                try:
+                    rival.execute("BEGIN IMMEDIATE")
+                    probe_results.append("acquired")
+                    rival.rollback()
+                except sqlite3.OperationalError as exc:
+                    probe_results.append(f"locked: {exc}")
+                finally:
+                    rival.close()
+            return result
+
+    @contextmanager
+    def probing_get_db():
+        with real_get_db() as conn:
+            yield LockProbingConnection(conn)
+
+    monkeypatch.setattr(checkouts_mod, "get_db", probing_get_db)
+    response = admin_client.post(
+        f"/api/items/{item_id}/checkout",
+        data={"borrower_id": str(borrower_id), "due_days": "14"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert probe_results, "checkout guard query never ran"
+    assert probe_results[0].startswith("locked"), (
+        "a rival writer acquired the database while checkout's active-loan "
+        f"guard was being read: {probe_results[0]!r}"
+    )

--- a/tests/test_mutation_integrity.py
+++ b/tests/test_mutation_integrity.py
@@ -1,0 +1,306 @@
+"""Regression tests for mutation paths that must not lose data or lie about success."""
+
+from app.database import get_db
+from tests.conftest import _insert_borrower, _insert_item, _insert_location
+
+
+def test_merge_rejects_primary_in_merge_ids(admin_client, db):
+    keep_id = _insert_item(db, title="Keep Me", isbn="9780306406157")
+    db.commit()
+
+    resp = admin_client.post(
+        "/api/items/merge",
+        json={"keep_id": keep_id, "merge_ids": [keep_id]},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is False
+    with get_db() as check_db:
+        assert check_db.execute("SELECT id FROM items WHERE id = ?", (keep_id,)).fetchone()
+
+
+def test_merge_deduplicates_targets_and_reports_actual_count(admin_client, db):
+    keep_id = _insert_item(db, title="Keep", isbn="9780306406157")
+    merge_id = _insert_item(db, title="Merge", isbn="9780140328721")
+    db.commit()
+
+    resp = admin_client.post(
+        "/api/items/merge",
+        json={"keep_id": keep_id, "merge_ids": [merge_id, merge_id, 999999999]},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "merged": 1}
+    with get_db() as check_db:
+        assert check_db.execute("SELECT id FROM items WHERE id = ?", (merge_id,)).fetchone() is None
+        assert check_db.execute("SELECT id FROM items WHERE id = ?", (keep_id,)).fetchone()
+
+
+def test_merge_first_nonempty_value_wins(admin_client, db):
+    keep_id = _insert_item(db, title="Keep", isbn="9780306406157", authors=None)
+    first_id = _insert_item(db, title="First", isbn="9780140328721", authors="First Author")
+    second_id = _insert_item(db, title="Second", isbn="9780547928227", authors="Second Author")
+    db.commit()
+
+    resp = admin_client.post(
+        "/api/items/merge",
+        json={"keep_id": keep_id, "merge_ids": [first_id, second_id]},
+    )
+
+    assert resp.json() == {"ok": True, "merged": 2}
+    with get_db() as check_db:
+        row = check_db.execute("SELECT authors FROM items WHERE id = ?", (keep_id,)).fetchone()
+    assert row["authors"] == "First Author"
+
+
+def test_merge_preserves_zero_valued_metadata(admin_client, db):
+    keep_id = _insert_item(
+        db, title="Keep Zero", isbn="9780306406157", manual_value=0, series_position=0
+    )
+    merge_id = _insert_item(
+        db, title="Merge Nonzero", isbn="9780140328721", manual_value=12.5, series_position=3
+    )
+    db.commit()
+
+    resp = admin_client.post(
+        "/api/items/merge",
+        json={"keep_id": keep_id, "merge_ids": [merge_id]},
+    )
+
+    assert resp.json() == {"ok": True, "merged": 1}
+    with get_db() as check_db:
+        row = check_db.execute(
+            "SELECT manual_value, series_position FROM items WHERE id = ?", (keep_id,)
+        ).fetchone()
+    assert row["manual_value"] == 0
+    assert row["series_position"] == 0
+
+
+def test_merge_rejects_multiple_active_loans(admin_client, db):
+    keep_id = _insert_item(db, title="Keep Lent", isbn="9780306406157")
+    merge_id = _insert_item(db, title="Merge Lent", isbn="9780140328721")
+    first_borrower = _insert_borrower(db, "Alice")
+    second_borrower = _insert_borrower(db, "Bob")
+    db.execute(
+        "INSERT INTO checkouts (item_id, borrower_id) VALUES (?, ?)",
+        (keep_id, first_borrower),
+    )
+    db.execute(
+        "INSERT INTO checkouts (item_id, borrower_id) VALUES (?, ?)",
+        (merge_id, second_borrower),
+    )
+    db.commit()
+
+    resp = admin_client.post(
+        "/api/items/merge",
+        json={"keep_id": keep_id, "merge_ids": [merge_id]},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is False
+    with get_db() as check_db:
+        assert check_db.execute("SELECT id FROM items WHERE id = ?", (keep_id,)).fetchone()
+        assert check_db.execute("SELECT id FROM items WHERE id = ?", (merge_id,)).fetchone()
+        active = check_db.execute(
+            "SELECT COUNT(*) AS c FROM checkouts WHERE checked_in IS NULL"
+        ).fetchone()["c"]
+    assert active == 2
+
+
+def test_merge_copies_isbn_pair_together(admin_client, db):
+    keep_id = _insert_item(db, title="Keep", isbn=None, isbn10=None)
+    merge_id = _insert_item(
+        db,
+        title="Merge",
+        isbn="9780547928227",
+        isbn10="054792822X",
+    )
+    db.commit()
+
+    resp = admin_client.post(
+        "/api/items/merge",
+        json={"keep_id": keep_id, "merge_ids": [merge_id]},
+    )
+
+    assert resp.json() == {"ok": True, "merged": 1}
+    with get_db() as check_db:
+        row = check_db.execute("SELECT isbn, isbn10 FROM items WHERE id = ?", (keep_id,)).fetchone()
+    assert dict(row) == {"isbn": "9780547928227", "isbn10": "054792822X"}
+
+
+def test_merge_preserves_loans_tags_and_item_links(admin_client, db):
+    keep_id = _insert_item(db, title="Keep", isbn="9780306406157")
+    merge_id = _insert_item(db, title="Merge", isbn="9780140328721")
+    linked_id = _insert_item(db, title="Linked", isbn="9780547928227")
+    borrower_id = _insert_borrower(db, "Alice")
+    tag_id = db.execute("INSERT INTO tags (name) VALUES ('Favourite')").lastrowid
+    db.execute(
+        "INSERT INTO checkouts (item_id, borrower_id, checked_out) VALUES (?, ?, datetime('now'))",
+        (merge_id, borrower_id),
+    )
+    db.execute("INSERT INTO item_tags (item_id, tag_id) VALUES (?, ?)", (merge_id, tag_id))
+    db.execute(
+        "INSERT INTO item_links (item_a_id, item_b_id, link_type) VALUES (?, ?, 'format')",
+        (merge_id, linked_id),
+    )
+    db.commit()
+
+    resp = admin_client.post(
+        "/api/items/merge",
+        json={"keep_id": keep_id, "merge_ids": [merge_id]},
+    )
+    assert resp.json() == {"ok": True, "merged": 1}
+
+    with get_db() as check_db:
+        checkout = check_db.execute(
+            "SELECT item_id FROM checkouts WHERE borrower_id = ?", (borrower_id,)
+        ).fetchone()
+        tag = check_db.execute(
+            "SELECT item_id FROM item_tags WHERE tag_id = ?", (tag_id,)
+        ).fetchone()
+        link = check_db.execute(
+            "SELECT item_a_id, item_b_id FROM item_links WHERE link_type = 'format'"
+        ).fetchone()
+    assert checkout["item_id"] == keep_id
+    assert tag["item_id"] == keep_id
+    assert {link["item_a_id"], link["item_b_id"]} == {keep_id, linked_id}
+
+
+def test_bulk_update_rejects_invalid_media_type(admin_client, db):
+    item_id = _insert_item(db, title="Bulk Type", isbn="9780306406157", media_type="book")
+    db.commit()
+
+    resp = admin_client.post(
+        "/api/items/bulk-update",
+        json={"item_ids": [item_id], "updates": {"media_type": "not-a-real-type"}},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is False
+    with get_db() as check_db:
+        row = check_db.execute("SELECT media_type FROM items WHERE id = ?", (item_id,)).fetchone()
+    assert row["media_type"] == "book"
+
+
+def test_bulk_update_rejects_missing_location(admin_client, db):
+    original_location = _insert_location(db, "Original")
+    item_id = _insert_item(
+        db, title="Bulk Location", isbn="9780306406157", location_id=original_location
+    )
+    db.commit()
+
+    resp = admin_client.post(
+        "/api/items/bulk-update",
+        json={"item_ids": [item_id], "updates": {"location_id": 999999999}},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is False
+    with get_db() as check_db:
+        row = check_db.execute("SELECT location_id FROM items WHERE id = ?", (item_id,)).fetchone()
+    assert row["location_id"] == original_location
+
+
+def test_bulk_update_rejects_non_boolean_owned_value(admin_client, db):
+    item_id = _insert_item(db, title="Bulk Owned", isbn="9780306406157", owned=1)
+    db.commit()
+
+    resp = admin_client.post(
+        "/api/items/bulk-update",
+        json={"item_ids": [item_id], "updates": {"owned": 7}},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is False
+    with get_db() as check_db:
+        row = check_db.execute("SELECT owned FROM items WHERE id = ?", (item_id,)).fetchone()
+    assert row["owned"] == 1
+
+
+def test_bulk_update_rejects_overlong_series_name(admin_client, db):
+    item_id = _insert_item(
+        db, title="Bulk Series", isbn="9780306406157", series_name="Original Series"
+    )
+    db.commit()
+
+    resp = admin_client.post(
+        "/api/items/bulk-update",
+        json={"item_ids": [item_id], "updates": {"series_name": "x" * 1001}},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is False
+    with get_db() as check_db:
+        row = check_db.execute("SELECT series_name FROM items WHERE id = ?", (item_id,)).fetchone()
+    assert row["series_name"] == "Original Series"
+
+
+def test_scan_move_rejects_missing_location_without_moving(admin_client, db):
+    original_location = _insert_location(db, "Original")
+    item_id = _insert_item(
+        db, title="Move Probe", isbn="9780000000030", location_id=original_location
+    )
+    db.commit()
+
+    resp = admin_client.post(
+        "/api/scan",
+        data={"isbn": "9780000000030", "mode": "move", "location_id": "999999999"},
+    )
+    assert resp.status_code == 200
+    assert b"Location not found" in resp.content
+    with get_db() as check_db:
+        row = check_db.execute("SELECT location_id FROM items WHERE id = ?", (item_id,)).fetchone()
+    assert row["location_id"] == original_location
+
+
+def test_scan_inventory_rejects_missing_location_without_moving(admin_client, db):
+    original_location = _insert_location(db, "Original")
+    item_id = _insert_item(
+        db, title="Inventory Probe", isbn="9780000000040", location_id=original_location
+    )
+    db.commit()
+
+    resp = admin_client.post(
+        "/api/scan",
+        data={"isbn": "9780000000040", "mode": "inventory", "location_id": "999999999"},
+    )
+    assert resp.status_code == 200
+    assert b"Location not found" in resp.content
+    with get_db() as check_db:
+        row = check_db.execute("SELECT location_id FROM items WHERE id = ?", (item_id,)).fetchone()
+    assert row["location_id"] == original_location
+
+
+def test_inventory_missing_rejects_unknown_location(admin_client):
+    resp = admin_client.post(
+        "/api/inventory/missing",
+        data={"location_id": "999999999", "scanned_ids": ""},
+    )
+    assert resp.status_code == 404
+    assert b"Location not found" in resp.content
+
+
+def test_checkout_rejects_unknown_item(admin_client, db):
+    borrower_id = _insert_borrower(db, "Borrower")
+    db.commit()
+
+    resp = admin_client.post(
+        "/api/items/999999999/checkout",
+        data={"borrower_id": str(borrower_id)},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["ok"] is False
+
+
+def test_checkout_rejects_unknown_borrower(admin_client, db):
+    item_id = _insert_item(db, title="Loan Probe", isbn="9780306406157")
+    db.commit()
+
+    resp = admin_client.post(
+        f"/api/items/{item_id}/checkout",
+        data={"borrower_id": "999999999"},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["ok"] is False
+
+
+def test_borrower_rejects_blank_name(admin_client):
+    resp = admin_client.post("/api/borrowers", data={"name": "   "})
+    assert resp.status_code == 400
+    assert resp.json()["ok"] is False

--- a/tests/test_platform_validation.py
+++ b/tests/test_platform_validation.py
@@ -1,0 +1,69 @@
+"""Regression coverage for Settings game-platform mutations."""
+
+
+def _insert_platform(db, name: str, slug: str) -> int:
+    cur = db.execute(
+        "INSERT INTO game_platforms (slug, name) VALUES (?, ?)",
+        (slug, name),
+    )
+    return cur.lastrowid
+
+
+def test_blank_platform_name_is_rejected(admin_client, db):
+    before = db.execute("SELECT COUNT(*) FROM game_platforms").fetchone()[0]
+
+    response = admin_client.post(
+        "/api/platforms",
+        data={"name": "   "},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/settings?platform_error=blank"
+    after = db.execute("SELECT COUNT(*) FROM game_platforms").fetchone()[0]
+    assert after == before
+
+
+def test_platform_slug_collision_is_reported_instead_of_silently_ignored(admin_client, db):
+    _insert_platform(db, "Play Station", "playstation")
+    db.commit()
+
+    response = admin_client.post(
+        "/api/platforms",
+        data={"name": "Play-Station"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/settings?platform_error=duplicate"
+    assert db.execute(
+        "SELECT COUNT(*) FROM game_platforms WHERE slug = 'playstation'"
+    ).fetchone()[0] == 1
+
+
+def test_delete_missing_platform_is_reported(admin_client):
+    response = admin_client.post(
+        "/api/platforms/999999/delete",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/settings?platform_error=missing"
+
+
+def test_known_platform_error_code_renders_fixed_banner(admin_client):
+    response = admin_client.get("/settings?platform_error=duplicate")
+
+    assert response.status_code == 200
+    assert 'data-testid="platform-error-banner"' in response.text
+    assert "A platform with that name or identifier already exists." in response.text
+
+
+def test_unknown_platform_error_code_is_not_reflected(admin_client):
+    response = admin_client.get(
+        "/settings?platform_error=%3Cscript%3Ealert(1)%3C%2Fscript%3E"
+    )
+
+    assert response.status_code == 200
+    assert 'data-testid="platform-error-banner"' not in response.text
+    assert "alert(1)" not in response.text

--- a/tests/test_scan_modes.py
+++ b/tests/test_scan_modes.py
@@ -13,10 +13,10 @@ class TestAddMode:
     """Default add mode — existing behavior, smoke tests."""
 
     def test_add_duplicate_returns_duplicate(self, admin_client, db):
-        item_id = _insert_item(db, title="Existing Book", isbn="9780000000001")
+        item_id = _insert_item(db, title="Existing Book", isbn="9780000000002")
         db.commit()
         resp = admin_client.post("/api/scan", data={
-            "isbn": "9780000000001", "media_type": "book", "mode": "add",
+            "isbn": "9780000000002", "media_type": "book", "mode": "add",
         })
         assert resp.status_code == 200
         assert b"duplicate" in resp.content
@@ -131,7 +131,6 @@ class TestMoveMode:
         assert b"moved" in resp.content
         assert "HX-Trigger" not in resp.headers
 
-        # Verify location was updated
         with get_db() as check_db:
             row = check_db.execute("SELECT location_id FROM items WHERE id = ?", (item_id,)).fetchone()
         assert row["location_id"] == loc_id
@@ -262,7 +261,7 @@ class TestGoogleBooksCredentialPropagation:
         with patch("app.routers.items_common._lookup_metadata", new=lookup), \
              patch("app.routers.items_common._fetch_preview_cover", new=AsyncMock(return_value=None)):
             admin_client.post("/api/scan", data={
-                "isbn": "9780000099986", "media_type": "book", "mode": "add",
+                "isbn": "9780000099983", "media_type": "book", "mode": "add",
             })
 
         assert lookup.await_args.kwargs["google_api_key"] == "scan-google-key"
@@ -272,7 +271,7 @@ class TestGoogleBooksCredentialPropagation:
         lookup = AsyncMock(return_value=(None, "manual", {}, provider_result.no_match("openlibrary")))
         with patch("app.routers.items_common._lookup_metadata", new=lookup):
             editor_client.post("/api/books/add", data={
-                "isbn": "9780000099979", "media_type": "book",
+                "isbn": "9780000099976", "media_type": "book",
             })
 
         assert lookup.await_args.kwargs["google_api_key"] == "add-google-key"
@@ -291,7 +290,7 @@ class TestManualAddForm:
             new=AsyncMock(return_value=None),
         ):
             return client.post("/api/scan", data={
-                "isbn": "9780000099993", "media_type": "book", "mode": "add",
+                "isbn": "9780000099990", "media_type": "book", "mode": "add",
             })
 
     def test_manual_form_has_copy_picker_and_new_fields(self, admin_client, db):
@@ -306,12 +305,9 @@ class TestManualAddForm:
         assert "Copy from an existing item" in html
         assert 'name="series_name"' in html
         assert 'name="location_id"' in html
-        # Locations must reach the fragment's context — this is wired at every
-        # render site that can show the form, and breaks silently if one is missed.
         assert "Living Room" in html
 
     def test_manual_form_renders_without_locations_configured(self, admin_client):
-        """No locations defined yet — the select still renders, empty."""
         resp = self._scan_unknown(admin_client)
         assert resp.status_code == 200
         assert 'name="location_id"' in resp.text
@@ -325,7 +321,6 @@ class TestRecentScans:
         assert b"No recent activity" in resp.content
 
     def test_recent_scans_filtered_by_mode(self, admin_client, db):
-        # Insert scan_log entries for different modes
         db.execute(
             "INSERT INTO scan_log (isbn, media_type, result, mode) VALUES (?, ?, ?, ?)",
             ("9780000000001", "book", "added", "add"),
@@ -394,7 +389,7 @@ class TestScanCoverQueue:
         from app.services import cover_queue
 
         metadata = {"title": "Polled Book", "authors": "A. Writer", "cover_id": 5}
-        resp, _ = self._scan(admin_client, "9780000000102", metadata)
+        resp, _ = self._scan(admin_client, "9780000000118", metadata)
         job = cover_queue._get_queue().get_nowait()
 
         html = resp.text
@@ -407,7 +402,7 @@ class TestScanCoverQueue:
 
         metadata = {"title": "HC Book", "authors": "A. Writer",
                     "cover_url": "https://hc.test/c.jpg"}
-        self._scan(admin_client, "9780000000103", metadata, source="hardcover")
+        self._scan(admin_client, "9780000000125", metadata, source="hardcover")
 
         job = cover_queue._get_queue().get_nowait()
         assert job.hints["cover_url"] is None
@@ -417,7 +412,7 @@ class TestScanCoverQueue:
         from app.services import cover_queue
 
         metadata = {"title": "Wanted Book", "authors": "A. Writer"}
-        resp, _ = self._scan(admin_client, "9780000000104", metadata, mode="wishlist")
+        resp, _ = self._scan(admin_client, "9780000000132", metadata, mode="wishlist")
         assert resp.status_code == 200
 
         job = cover_queue._get_queue().get_nowait()
@@ -461,7 +456,6 @@ class TestCoverStatusEndpoint:
         assert "data-cover-settled" in resp.text
 
     def test_unknown_item_settles_with_200(self, admin_client):
-        """An item deleted mid-poll must not produce an htmx error swap."""
         resp = admin_client.get("/api/items/999999/cover-status?attempt=1")
         assert resp.status_code == 200
         assert "hx-get" not in resp.text
@@ -525,7 +519,6 @@ class TestTheBarcodeOutranksTheDropdown:
     def test_an_isbn_keeps_a_book_family_hint_the_barcode_cannot_contradict(
         self, admin_client, db, stub_book_lookup, hint
     ):
-        """Tier 1 honours these — no barcode signal can tell them apart."""
         admin_client.post("/api/scan", data={
             "isbn": self.ISBN, "media_type": hint, "mode": "add",
         })
@@ -538,7 +531,6 @@ class TestTheBarcodeOutranksTheDropdown:
     def test_an_isbn_with_no_usable_hint_is_stored_as_a_book_never_the_hint(
         self, admin_client, db, stub_book_lookup, hint
     ):
-        """`auto` must never reach the database — the whole point of tier 4."""
         admin_client.post("/api/scan", data={
             "isbn": self.ISBN, "media_type": hint, "mode": "add",
         })
@@ -550,11 +542,6 @@ class TestTheBarcodeOutranksTheDropdown:
     def test_the_duplicate_check_keys_on_the_resolved_type_not_the_hint(
         self, admin_client, db, stub_book_lookup
     ):
-        """A book already on the shelf dedupes against a stale "dvd" scan.
-
-        Before detection the check ran on the hint, so this scan missed the
-        existing row and tried to file a second one.
-        """
         _insert_item(db, title="Already A Book", isbn=self.ISBN, media_type="book")
         db.commit()
 

--- a/tests/test_write_targets.py
+++ b/tests/test_write_targets.py
@@ -1,0 +1,103 @@
+"""Regression coverage for stale/tampered write targets."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.write_targets import UnknownLocationError, validated_location_id
+from tests.conftest import _insert_location
+
+
+class TestValidatedLocationId:
+    def test_no_location_sentinels_normalise_to_none(self, db):
+        assert validated_location_id(db, None) is None
+        assert validated_location_id(db, 0) is None
+        assert validated_location_id(db, -1) is None
+
+    def test_existing_location_is_returned(self, db):
+        location_id = _insert_location(db, "Valid Target")
+        assert validated_location_id(db, location_id) == location_id
+
+    def test_unknown_positive_location_is_rejected(self, db):
+        with pytest.raises(UnknownLocationError):
+            validated_location_id(db, 999999)
+
+
+class TestCatalogueLocationTargets:
+    def test_game_add_rejects_stale_location_before_igdb_lookup(
+        self, editor_client, db, monkeypatch
+    ):
+        from app.routers import items_catalog
+
+        db.execute("INSERT INTO settings (key, value) VALUES ('igdb_client_id', 'cid')")
+        db.execute("INSERT INTO settings (key, value) VALUES ('igdb_client_secret', 'secret')")
+        db.commit()
+
+        lookup = AsyncMock(return_value={"title": "Target Probe"})
+        monkeypatch.setattr(items_catalog.igdb, "lookup_game", lookup)
+
+        resp = editor_client.post(
+            "/api/games/add",
+            data={"igdb_id": "123", "location_id": "999999"},
+        )
+
+        assert resp.status_code == 200
+        assert "location" in resp.text.lower()
+        lookup.assert_not_awaited()
+        assert db.execute("SELECT COUNT(*) FROM items").fetchone()[0] == 0
+
+    def test_book_add_rejects_stale_location_before_metadata_lookup(
+        self, editor_client, db, monkeypatch
+    ):
+        from app.routers import items_common
+
+        lookup = AsyncMock(return_value=(
+            {"title": "Target Probe"}, "openlibrary", {}, False,
+        ))
+        monkeypatch.setattr(items_common, "_lookup_metadata", lookup)
+
+        resp = editor_client.post(
+            "/api/books/add",
+            data={
+                "isbn": "9780306406157",
+                "media_type": "book",
+                "location_id": "999999",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert "location" in resp.text.lower()
+        lookup.assert_not_awaited()
+        assert db.execute("SELECT COUNT(*) FROM items").fetchone()[0] == 0
+
+    def test_dvd_add_rejects_stale_location_without_inserting(self, editor_client, db):
+        resp = editor_client.post(
+            "/api/dvds/add",
+            data={
+                "title": "Target Probe",
+                "tmdb_id": "42",
+                "location_id": "999999",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert "location" in resp.text.lower()
+        assert db.execute("SELECT COUNT(*) FROM items").fetchone()[0] == 0
+
+
+class TestCoverSelectionTarget:
+    def test_unknown_item_is_rejected_before_cover_download(
+        self, editor_client, monkeypatch
+    ):
+        from app.routers import items_covers
+
+        download = AsyncMock(return_value="covers/999999.jpg")
+        monkeypatch.setattr(items_covers.covers, "_download_to_item", download)
+
+        resp = editor_client.post(
+            "/api/items/999999/cover-select",
+            data={"url": "https://covers.openlibrary.org/b/id/123-L.jpg"},
+        )
+
+        assert resp.status_code == 404
+        download.assert_not_awaited()


### PR DESCRIPTION
Complete the remaining unsent product-smoke and mutation-boundary audit work in one reviewable commit.

Catalogue and lending integrity
- validate ISBN checksums and canonical ISBN pairs across catalogue writes
- harden bulk updates, merge operations, scan targets, borrower mutations and checkout targets
- preserve related catalogue data during merges and reject unsafe merge states
- serialize checkout creation so concurrent requests cannot create contradictory active loans

Browse and write targets
- make Browse selection and bulk controls role-aware
- report partial and failed bulk deletes truthfully instead of always showing success
- reject stale catalogue locations before provider lookups or inserts
- reject cover selection for missing items before network or filesystem work

Item editing
- validate numeric, enum, ownership, location and title fields before mutation
- reject catalogue conflicts cleanly and avoid partial cover writes
- reject invalid quick reading-status values instead of silently clearing state

Integration request boundaries
- reject malformed IGDB credential-test bodies before outbound requests
- validate Hardcover credential-test and add-to-shelf request shapes before network or catalogue work
- retain the Hardcover invalid-schedule guard needed by the shared router state

Platform administration
- report blank names, slug collisions and stale platform deletions truthfully
- render fixed whitelisted Settings feedback for platform and borrower mutation errors

Testing
- add focused unit regressions for catalogue, merge, lending, write-target, item-edit, platform, IGDB and Hardcover boundaries
- add browser regressions for role-aware Browse controls and failed bulk-delete feedback

This commit is rebuilt directly on upstream 0.26.0 (a3910c1). It intentionally excludes the unrelated changes already proposed in upstream PRs #56-#78. Two small shared-file dependency pieces overlap existing reviews: Browse's CSP-safe parseInt helper from #75 and the Hardcover invalid-schedule guard from #61.

<!--
Thanks for contributing to Shelf! For anything bigger than a small fix,
please open an issue first so we can talk about the approach before you
invest time — see CONTRIBUTING.md.
-->

## What this changes

<!-- A sentence or two. If it fixes an open issue, add "Fixes #123". -->

## Why

<!-- What problem does this solve? For a bug, what was the user-visible
     symptom? Skip if the "what" already makes it obvious. -->

## How it was tested

<!-- Which of the checks below you ran, plus anything you exercised by hand
     (which browser, which device, which scanner). -->

- [ ] `make test` passes
- [ ] `make test-e2e` passes
- [ ] `make checks` passes
- [ ] `make css` re-run, if templates or Tailwind classes changed

## Notes for review

<!-- Anything you're unsure about, deliberately left out, or want a second
     opinion on. Screenshots or a short clip help a lot for UI changes. -->

---

A few project-specific things that are easy to trip over — see `GOTCHAS.md`:

- Unit and E2E tests **cannot** share a pytest invocation; use the Make targets.
- Raw `fetch()` calls must send the `X-CSRF-Token` header (`make check-csrf`).
- Templates must stay compatible with the Alpine.js **CSP build**
  (`make check-alpine`) — nested or bracketed `x-model` bindings silently
  drop input.
- `MIGRATIONS` in `app/database.py` is append-only. Never edit or reorder an
  existing entry; add a new one at the end.
- No CDN references — all JS and CSS is vendored in `static/`.
