### PR TITLE
Fix UPC-A check digit validation

### DIFF
--- a/app/services/upc.py
+++ b/app/services/upc.py
@@ -40,10 +40,15 @@ def detect_barcode_type(code: str) -> str:
 
 
 def validate_upc(code: str) -> bool:
-    """Validate a UPC-A (12-digit) check digit."""
+    """Validate a UPC-A (12-digit) check digit.
+
+    UPC-A weights positions 1, 3, 5, ... by three and positions 2, 4, 6, ...
+    by one. The previous implementation had those weights reversed, which
+    rejected valid retail barcodes such as 078073003501.
+    """
     code = normalize_barcode(code)
     if len(code) != 12 or not code.isdigit():
         return False
-    total = sum(int(d) * (3 if i % 2 else 1) for i, d in enumerate(code[:11]))
+    total = sum(int(d) * (3 if i % 2 == 0 else 1) for i, d in enumerate(code[:11]))
     check = (10 - (total % 10)) % 10
     return int(code[11]) == check

--- a/tests/test_isbn.py
+++ b/tests/test_isbn.py
@@ -190,9 +190,13 @@ class TestDetectBarcodeType:
 class TestValidateUpc:
     def test_valid_upc(self):
         assert validate_upc("012345678905") is True
+        assert validate_upc("036000291452") is True
+        assert validate_upc("078073003501") is True
 
     def test_invalid_check_digit(self):
         assert validate_upc("012345678900") is False
+        assert validate_upc("036000291453") is False
+        assert validate_upc("078073003502") is False
 
     def test_wrong_length(self):
         assert validate_upc("12345") is False


### PR DESCRIPTION
## Summary
Fix UPC-A check-digit validation by applying the standard weighting:
- positions 1, 3, 5, ... are weighted by 3;
- positions 2, 4, 6, ... are weighted by 1.
The previous implementation applied those weights in reverse, causing valid retail UPC-A values such as `036000291452` and `078073003501` to be rejected.
## Tests
Added focused regression vectors covering:
- valid UPC-A values: `012345678905`, `036000291452`, `078073003501`;
- invalid check digits: `012345678900`, `036000291453`, `078073003502`.
Verification completed before opening this PR:
- focused UPC/route tests: 177 passed;
- static checks passed: CSRF, Alpine CSP, service-worker version, badges, UTF-8 convention lint, and whitespace;
- full unit suite: 2449 passed with 14 unrelated Windows/environment failures involving archive file locks, POSIX permissions, and CP1252 decoding.
No migrations, data changes, or unrelated functionality are included.
Requested by @dgahagan in martialartistslife/shelf#9.