### PR TITLE
Fix infinite scroll appending unstyled grid cards in list view

### DIFF
--- a/app/routers/items.py
+++ b/app/routers/items.py
@@ -801,8 +801,9 @@ async def search_items(
     if tag:
         from urllib.parse import quote
         qs_parts.append(f"tag={quote(tag)}")
-    if view:
-        qs_parts.append(f"view={view}")
+    # NOTE: `view` is deliberately NOT baked into the URL — the load-more
+    # element sends it via hx-include="[name='view']" so the fragment always
+    # matches the view mode currently rendered on the client.
     qs_parts.append(f"page={page + 1}")
     load_more_url = "/api/search?" + "&".join(qs_parts)
 

--- a/app/templates/fragments/item_cards_page.html
+++ b/app/templates/fragments/item_cards_page.html
@@ -3,7 +3,8 @@
 {% endfor %}
 {% if has_more is defined and has_more %}
 <div id="load-more" class="col-span-full text-center py-4"
-     hx-get="{{ load_more_url }}" hx-trigger="revealed" hx-swap="outerHTML">
+     hx-get="{{ load_more_url }}" hx-trigger="revealed" hx-swap="outerHTML"
+     hx-include="[name='view']">
     <div class="inline-block w-6 h-6 border-2 border-shelf-border border-t-shelf-accent rounded-full animate-spin"></div>
 </div>
 {% endif %}

--- a/app/templates/fragments/item_grid.html
+++ b/app/templates/fragments/item_grid.html
@@ -6,7 +6,8 @@
     {% endfor %}
     {% if has_more is defined and has_more %}
     <div id="load-more" class="col-span-full text-center py-4"
-         hx-get="{{ load_more_url }}" hx-trigger="revealed" hx-swap="outerHTML">
+         hx-get="{{ load_more_url }}" hx-trigger="revealed" hx-swap="outerHTML"
+         hx-include="[name='view']">
         <div class="inline-block w-6 h-6 border-2 border-shelf-border border-t-shelf-accent rounded-full animate-spin"></div>
     </div>
     {% endif %}
@@ -30,14 +31,16 @@
             {% for item in items %}
             {% include "fragments/item_row.html" %}
             {% endfor %}
+            {% if has_more is defined and has_more %}
+            <tr id="load-more" hx-get="{{ load_more_url }}" hx-trigger="revealed"
+                hx-swap="outerHTML" hx-include="[name='view']">
+                <td colspan="7" class="text-center py-4">
+                    <div class="inline-block w-6 h-6 border-2 border-shelf-border border-t-shelf-accent rounded-full animate-spin"></div>
+                </td>
+            </tr>
+            {% endif %}
         </tbody>
     </table>
-    {% if has_more is defined and has_more %}
-    <div id="load-more" class="text-center py-4"
-         hx-get="{{ load_more_url }}" hx-trigger="revealed" hx-swap="outerHTML">
-        <div class="inline-block w-6 h-6 border-2 border-shelf-border border-t-shelf-accent rounded-full animate-spin"></div>
-    </div>
-    {% endif %}
 </div>
 </template>
 {% else %}

--- a/app/templates/fragments/item_rows_page.html
+++ b/app/templates/fragments/item_rows_page.html
@@ -2,9 +2,9 @@
 {% include "fragments/item_row.html" %}
 {% endfor %}
 {% if has_more is defined and has_more %}
-<tr id="load-more" class="col-span-full">
-    <td colspan="7" class="text-center py-4"
-        hx-get="{{ load_more_url }}" hx-trigger="revealed" hx-swap="outerHTML">
+<tr id="load-more" hx-get="{{ load_more_url }}" hx-trigger="revealed"
+    hx-swap="outerHTML" hx-include="[name='view']">
+    <td colspan="7" class="text-center py-4">
         <div class="inline-block w-6 h-6 border-2 border-shelf-border border-t-shelf-accent rounded-full animate-spin"></div>
     </td>
 </tr>

--- a/tests/e2e/test_browse.py
+++ b/tests/e2e/test_browse.py
@@ -82,3 +82,65 @@ def test_browse_url_state_preserved(live_server, authed_page):
     authed_page.goto(f"{live_server['url']}/browse?mt=book")
     authed_page.wait_for_load_state("networkidle")
     assert "mt=book" in authed_page.url or authed_page.locator("body").is_visible()
+
+
+def _seed_many(data_dir, prefix: str, count: int) -> None:
+    """Bulk-insert `count` items in one connection (insert_item is per-row)."""
+    import sqlite3
+
+    conn = sqlite3.connect(str(data_dir / "shelf.db"))
+    try:
+        conn.executemany(
+            "INSERT INTO items (title, media_type, source, owned) VALUES (?, 'book', 'test', 1)",
+            [(f"{prefix} {i:03d}",) for i in range(count)],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _scroll_until_loaded(page, max_rounds: int = 12) -> None:
+    """Scroll to the bottom until the load-more sentinel is gone."""
+    for _ in range(max_rounds):
+        if page.locator("#load-more").count() == 0:
+            return
+        page.mouse.wheel(0, 20000)
+        page.wait_for_timeout(600)
+
+
+@pytest.mark.parametrize("view_mode", ["grid", "list"])
+def test_browse_infinite_scroll_matches_view_mode(live_server, authed_page, view_mode):
+    """Infinite scroll appends fragments matching the active view mode.
+
+    Regression: the load-more URL did not carry the client-side view mode, so
+    in list view every appended page came back as grid cards, which landed
+    outside the table as unstyled markup and stalled pagination.
+    """
+    _seed_many(live_server["data_dir"], f"Scroll {view_mode}", 130)
+
+    authed_page.set_viewport_size({"width": 390, "height": 844})
+    authed_page.goto(f"{live_server['url']}/browse")
+    authed_page.evaluate(f"localStorage.setItem('shelf-view', '{view_mode}')")
+    authed_page.reload()
+    authed_page.wait_for_load_state("networkidle")
+
+    _scroll_until_loaded(authed_page)
+
+    cards = authed_page.locator("a[data-item-id]")
+    rows = authed_page.locator("tr[data-item-id]")
+    if view_mode == "grid":
+        assert cards.count() >= 130, f"only {cards.count()} cards loaded"
+        assert rows.count() == 0, "list rows leaked into grid view"
+        # Every card belongs to the grid container.
+        assert authed_page.evaluate(
+            "document.querySelectorAll('a[data-item-id]:not(.cover-grid > a)').length"
+        ) == 0
+    else:
+        assert rows.count() >= 130, f"only {rows.count()} rows loaded"
+        assert cards.count() == 0, "grid cards leaked into list view"
+        # Every row is inside the table body, not hoisted out by the parser.
+        assert authed_page.evaluate(
+            "document.querySelectorAll('tr[data-item-id]:not(tbody > tr)').length"
+        ) == 0
+
+    assert authed_page.locator("#load-more").count() == 0, "pagination stalled"


### PR DESCRIPTION
## The bug

On the Browse page in **list view**, infinite scroll breaks: the second page of results is appended as unstyled markup below the table, and pagination then stalls entirely. Grid view is unaffected.

Reproduced at a 390px viewport with 150 seeded items — the page rendered 60 rows, appended 60 `<a>` cover cards directly under the table's wrapper `div`, and stopped at 120 of 150.

## Root cause

Three compounding defects:

1. **The view mode never reached the load-more request.** `/browse` builds `load_more_url` server-side (`app/routers/pages.py`), but `viewMode` lives in `localStorage`, so the server can't know it. The first load-more after any page load hit `/api/search?page=2` with no `view`, which the endpoint defaults to grid. `app/routers/items.py` only re-appended `view` when it was non-empty, so the omission propagated to every subsequent page.

2. **The list-view sentinel sat outside the table.** `item_grid.html` placed the list `#load-more` after `</table>`, even though page 2+ returns bare `<tr>` rows meant for `<tbody>`.

3. **The wrong element was being swapped.** `item_rows_page.html` put `id="load-more"` on the `<tr>` but `hx-get`/`hx-swap="outerHTML"` on the `<td>`, so a swap replaced the *cell* and nested `<tr>` inside `<tr>`.

## The fix

- Load-more elements now carry `hx-include="[name='view']"`, sending the live view mode from the hidden input `browse.html` already renders. The redundant URL param is dropped from `items.py` so the two sources can't disagree.
- The list sentinel moved into `<tbody>` as a proper `<tr>`, with the htmx attributes on the row itself.

## Verification

- Both view modes now load all 150 items; rows land inside `<tbody>`, with no stray nodes and no leftover sentinel.
- 467 unit tests, 36 e2e tests, and both `check_alpine_csp` / `check_csrf_fetch` lints pass.
- Added a parametrized e2e regression test covering both view modes at a mobile viewport. Confirmed it fails on the pre-fix code (`only 60 rows loaded`) by reverting the source changes and re-running it.

## Notes for reviewers

The fix relies on the hidden `<input name="view">` in `browse.html` being present. If Alpine fails to initialize, `hx-include` contributes nothing and the request falls back to grid — the previous behavior, so no new failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)