### PR TITLE
Fetch the Open Library work record once per ISBN lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to Shelf are documented here. The format follows
 
 ## [Unreleased]
 
+### Changed
+
+- **Adding a book by ISBN makes one fewer Open Library request.** The work
+  record backs both the author chain and the description, and each resolver
+  was fetching it separately — the same document twice, a round trip and a
+  rate limiter gate apart. Open Library edition and work requests routinely
+  take a second or more each, so scanning now settles noticeably sooner. The
+  result is unchanged, including a failed work or author request still
+  returning the edition it already had.
+
 ### Fixed
 
 - UPC-A check digits are validated with the standard weighting (odd positions

--- a/app/services/openlibrary.py
+++ b/app/services/openlibrary.py
@@ -98,11 +98,17 @@ async def lookup(isbn: str, client: httpx.AsyncClient) -> provider_result.Provid
     # (G47). The edition is already a hit — a failed enrichment costs fields,
     # not the result.
     try:
-        author = await _resolve_author(data, client)
+        # The work record backs both the author chain and the description, so
+        # fetch it once and share it. Two requests for the same document cost
+        # a round trip plus a rate limiter gate on every ISBN add.
+        work_key = _work_key(data)
+        work = await _fetch_work(work_key, client) if work_key else None
+
+        author = await _resolve_author(data, work, client)
         if author:
             result["authors"] = author
 
-        desc = await _resolve_description(data, client)
+        desc = _work_description(work)
         if desc:
             result["description"] = desc
     except Exception:
@@ -111,9 +117,36 @@ async def lookup(isbn: str, client: httpx.AsyncClient) -> provider_result.Provid
     return provider_result.found("openlibrary", result, status=resp.status_code)
 
 
-async def _resolve_author(edition_data: dict, client: httpx.AsyncClient) -> str | None:
+def _work_key(edition_data: dict) -> str | None:
+    """The key of the edition's primary work (e.g. '/works/OL27448W'), if any."""
     works = edition_data.get("works", [])
-    if not works:
+    if not works or not isinstance(works[0], dict):
+        return None
+    return works[0].get("key")
+
+
+async def _fetch_work(work_key: str, client: httpx.AsyncClient) -> dict | None:
+    """Fetch a work record (e.g. '/works/OL27448W'). Returns the JSON or None."""
+    await _rate_limit()
+    resp = await client.get(
+        f"https://openlibrary.org{work_key}.json",
+        headers={"User-Agent": USER_AGENT},
+        follow_redirects=True,
+    )
+    if resp.status_code != 200:
+        return None
+    return resp.json()
+
+
+async def _resolve_author(edition_data: dict, work: dict | None,
+                          client: httpx.AsyncClient) -> str | None:
+    """Resolve an author name from the already-fetched work record.
+
+    An edition with no work of its own falls back to its own author list; a
+    work we failed to fetch simply yields no author, leaving the rest of the
+    hit intact.
+    """
+    if _work_key(edition_data) is None:
         # Some editions have authors directly
         authors = edition_data.get("authors", [])
         if authors and isinstance(authors[0], dict):
@@ -122,16 +155,9 @@ async def _resolve_author(edition_data: dict, client: httpx.AsyncClient) -> str 
                 return await _fetch_author_name(akey, client)
         return None
 
-    await _rate_limit()
-    work_resp = await client.get(
-        f"https://openlibrary.org{works[0]['key']}.json",
-        headers={"User-Agent": USER_AGENT},
-        follow_redirects=True,
-    )
-    if work_resp.status_code != 200:
+    if not work:
         return None
 
-    work = work_resp.json()
     authors = work.get("authors", [])
     if not authors:
         return None
@@ -159,31 +185,20 @@ async def _fetch_author_name(author_key: str, client: httpx.AsyncClient) -> str 
     return resp.json().get("name")
 
 
-async def _resolve_description(edition_data: dict, client: httpx.AsyncClient) -> str | None:
-    works = edition_data.get("works", [])
-    if not works:
+def _work_description(work: dict | None) -> str | None:
+    """Pull the description out of a work record, which Open Library returns
+    either as a plain string or as a {type, value} object."""
+    if not work:
         return None
-
-    # We may have already fetched the work in _resolve_author, but keeping it
-    # simple — the rate limiter handles it
-    return await get_work_description(works[0]["key"], client)
+    desc = work.get("description")
+    if isinstance(desc, dict):
+        return desc.get("value")
+    return desc
 
 
 async def get_work_description(work_key: str, client: httpx.AsyncClient) -> str | None:
     """Fetch a work record (e.g. '/works/OL27448W') and return its description."""
-    await _rate_limit()
-    resp = await client.get(
-        f"https://openlibrary.org{work_key}.json",
-        headers={"User-Agent": USER_AGENT},
-        follow_redirects=True,
-    )
-    if resp.status_code != 200:
-        return None
-
-    desc = resp.json().get("description")
-    if isinstance(desc, dict):
-        return desc.get("value")
-    return desc
+    return _work_description(await _fetch_work(work_key, client))
 
 
 _SEARCH_FIELDS = ("key,title,author_name,first_publish_year,publisher,cover_i,isbn,"

--- a/tests/test_outbound_clients.py
+++ b/tests/test_outbound_clients.py
@@ -342,6 +342,56 @@ class TestOpenLibraryOutcomes:
         assert "authors" not in result.payload
         assert "description" not in result.payload
 
+    @respx.mock
+    async def test_the_work_is_fetched_once_for_author_and_description(self):
+        """The work record backs both the author chain and the description.
+        Fetching it once per resolver made every ISBN add pay an extra round
+        trip plus an extra rate limiter gate for a document already in hand."""
+        respx.get("https://openlibrary.org/isbn/9780000000088.json").mock(
+            return_value=httpx.Response(200, json={
+                "title": "Whole A Book", "works": [{"key": "/works/OL2W"}],
+            })
+        )
+        work = respx.get("https://openlibrary.org/works/OL2W.json").mock(
+            return_value=httpx.Response(200, json={
+                "authors": [{"author": {"key": "/authors/OL3A"}}],
+                "description": "A blurb.",
+            })
+        )
+        respx.get("https://openlibrary.org/authors/OL3A.json").mock(
+            return_value=httpx.Response(200, json={"name": "Some Author"})
+        )
+        async with httpx.AsyncClient() as client:
+            result = await openlibrary.lookup("9780000000088", client)
+
+        assert work.call_count == 1
+        assert result.payload["authors"] == "Some Author"
+        assert result.payload["description"] == "A blurb."
+        # edition + work + author, and nothing more
+        assert len(respx.calls) == 3
+
+    @respx.mock
+    async def test_an_edition_with_no_work_asks_for_no_work(self):
+        """The other side of sharing one fetch: an edition carrying its own
+        authors still resolves them without a work request at all."""
+        respx.get("https://openlibrary.org/isbn/9780000000095.json").mock(
+            return_value=httpx.Response(200, json={
+                "title": "Workless", "authors": [{"key": "/authors/OL3A"}],
+            })
+        )
+        work = respx.get("https://openlibrary.org/works/OL2W.json").mock(
+            return_value=httpx.Response(200, json={"description": "Unused."})
+        )
+        respx.get("https://openlibrary.org/authors/OL3A.json").mock(
+            return_value=httpx.Response(200, json={"name": "Some Author"})
+        )
+        async with httpx.AsyncClient() as client:
+            result = await openlibrary.lookup("9780000000095", client)
+
+        assert work.call_count == 0
+        assert result.payload["authors"] == "Some Author"
+        assert "description" not in result.payload
+
 
 class TestDnbOutcomes:
     """T2 — `lookup` now returns a `ProviderResult` instead of a bare


### PR DESCRIPTION
## What this changes

`openlibrary.lookup()` fetches the work record once and shares it between the
author chain and the description, instead of fetching the same document twice.
An ISBN lookup makes three Open Library requests instead of four.

## Why

Adding a book by ISBN made four sequential requests, each behind the per-host
rate limiter, and two of them were the same work record — once through
`_resolve_author`, once through `_resolve_description` → `get_work_description`.

The comment on the second fetch conceded the duplication:

```python
# We may have already fetched the work in _resolve_author, but keeping it
# simple — the rate limiter handles it
```

The limiter does handle it, by making it strictly slower. It cannot skip a
request that was issued, so the second fetch of a document already in hand
costs a full round trip *plus* a gate. Open Library edition/work requests
routinely take a second or more each, so that is dead time the scan card sits
on with every add.

Behaviour is unchanged, including the contracts the enrichment leg documents:

- A non-200 on the work or author request still returns the edition hit minus
  those fields, rather than laundering it into "no such book" (G47). The work
  fetch sits inside the same `try` as before, so a dead socket there is still
  caught by the enrichment guard.
- An edition with no work of its own still falls back to its own author list,
  without asking for a work at all.
- `get_work_description()` stays a standalone entry point — `services/synopsis.py`
  calls it directly for the backfill — now sharing `_fetch_work` with `lookup`.

One incidental hardening: `_work_key` reads `works[0].get("key")`, so a
malformed `works` entry no longer raises `KeyError` where the old
`works[0]['key']` would have.

## How it was tested

- [x] `make test` passes — 2495 passed. The one failure is
      `test_badge_stamp.py::test_readme_badges_are_current`, which is the
      expected local result for a PR that adds tests; it is `skipif`-ed on
      `GITHUB_EVENT_NAME == pull_request`, and I have deliberately **not**
      restamped the badge, per that test's own docstring about restamps
      colliding across a batch of PRs. Verified green under a PR context:
      `GITHUB_EVENT_NAME=pull_request pytest tests/test_badge_stamp.py` →
      5 passed, 1 skipped.
- [ ] `make test-e2e` — not run.
- [ ] `make checks` — not run in full. The change is one service module with no
      new dependencies, no template or JS changes, and no migration, so the
      CSRF/Alpine/CSS gates are untouched; `test_csrf_lint` and
      `test_alpine_csp_lint` pass as part of the suite above.
- [ ] `make css` — not applicable, no templates or Tailwind classes touched.

Two tests added to `TestOpenLibraryOutcomes` in `tests/test_outbound_clients.py`,
alongside the existing enrichment-failure test:

- `test_the_work_is_fetched_once_for_author_and_description` asserts
  `work.call_count == 1` and a total of three calls, so the redundant fetch
  cannot come back unnoticed. Confirmed non-vacuous: it fails `assert 2 == 1`
  against `main` as it stands.
- `test_an_edition_with_no_work_asks_for_no_work` covers the other side of
  sharing one fetch.

## Notes for review

- Deliberately left out: the same request path also does an extra Hardcover
  round trip when a token is configured. `_lookup_metadata`'s "enrich if series
  or description is missing" leg fires on essentially every add, because Open
  Library never carries series data — so it is a guaranteed serial lookup
  waiting out the whole Open Library chain, and the Google-Books fallback path
  issues two full Hardcover lookups. Running it concurrently with the primary
  leg looks like a clear win, but it touches the `ProviderResult` cascade's
  `legs` ordering and the national-provider short-circuit, which have careful
  documented semantics. That felt like it wanted its own issue and its own PR
  rather than being folded in here. Happy to open one if you'd like it.
- Also on that path: both `/api/scan` and `/api/books/add` download the cover
  inline before responding. `covers.download_cover`'s first candidate needs
  only `cover_id`, which arrives with the *edition* record, so it could overlap
  the work/author requests — but that needs `lookup` split into two phases and
  `download_cover` decoupled from `item_id`. Noted, not attempted.
- I have not exercised this against the live Open Library API, only against the
  respx mocks in the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
