### PR TITLE
Allow manual cover image URLs

### DIFF
--- a/app/routers/items_covers.py
+++ b/app/routers/items_covers.py
@@ -18,7 +18,7 @@ from app.auth import require_role
 from app.config import COVERS_DIR, HTTP_TIMEOUT
 from app.database import get_db, get_setting
 from app.routers import items_common
-from app.services import covers, cover_queue, openlibrary, scan_outcome
+from app.services import covers, cover_queue, manual_cover, openlibrary, scan_outcome
 from app.services import isbn as isbn_svc
 
 logger = logging.getLogger(__name__)
@@ -224,6 +224,39 @@ async def cover_select(
     )
     resp.headers["HX-Trigger"] = items_common._toast_header("Failed to download cover", "error")
     return resp
+
+
+@router.post("/items/{item_id}/cover-url")
+async def cover_from_url(
+    item_id: int,
+    url: str = Form(...),
+    _=Depends(require_role("editor")),
+):
+    """Use a user-pasted public HTTPS image as an item's cover."""
+    with get_db() as db:
+        item = db.execute("SELECT id FROM items WHERE id = ?", (item_id,)).fetchone()
+    if not item:
+        return HTMLResponse("Not found", status_code=404)
+
+    cover_path = await manual_cover.download(item_id, url)
+    if not cover_path:
+        resp = HTMLResponse("")
+        resp.headers["HX-Trigger"] = items_common._toast_header(
+            "Could not use that cover URL — use a public HTTPS JPEG, PNG, GIF or WebP under 10 MB",
+            "error",
+        )
+        return resp
+
+    with get_db() as db:
+        db.execute(
+            "UPDATE items SET cover_path = ?, updated_at = datetime('now') WHERE id = ?",
+            (cover_path, item_id),
+        )
+    resp = HTMLResponse("")
+    resp.headers["HX-Trigger"] = items_common._toast_header("Cover updated")
+    resp.headers["HX-Redirect"] = f"/item/{item_id}"
+    return resp
+
 
 @router.post("/items/{item_id}/cover-upload")
 async def cover_upload(request: Request, item_id: int, _=Depends(require_role("editor"))):

--- a/app/services/manual_cover.py
+++ b/app/services/manual_cover.py
@@ -1,0 +1,155 @@
+"""Safe downloader for user-supplied cover image URLs.
+
+Provider artwork already uses Shelf's static cover-domain allowlist. A manually
+pasted URL intentionally needs to work with arbitrary public image hosts, so it
+has a different boundary: public HTTPS only, with DNS resolution pinned to the
+address that was validated before the connection is opened. Every redirect is
+resolved and validated again.
+"""
+
+import asyncio
+import ipaddress
+import logging
+import socket
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+from app.config import COVERS_DIR, HTTP_TIMEOUT
+from app.services import covers, outbound
+
+logger = logging.getLogger(__name__)
+
+_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+_MAX_REDIRECTS = 5
+
+
+class _PinnedIPTransport(httpx.AsyncBaseTransport):
+    """Connect to one validated IP while preserving the URL hostname for TLS.
+
+    The request is built against the original hostname, so its Host header is
+    already correct. Only the transport destination is replaced. httpcore's
+    ``sni_hostname`` request extension keeps TLS certificate verification tied
+    to the original hostname instead of the pinned IP address.
+    """
+
+    def __init__(self, address: str, transport: httpx.AsyncBaseTransport | None = None):
+        self._address = address
+        self._transport = transport or httpx.AsyncHTTPTransport()
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        hostname = request.url.host
+        request.extensions["sni_hostname"] = hostname
+        request.url = request.url.copy_with(host=self._address)
+        return await self._transport.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        await self._transport.aclose()
+
+
+def _is_public(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return address.is_global
+
+
+async def _resolve_addresses(host: str, port: int) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    """Resolve ``host`` off the event loop and return all usable addresses."""
+    try:
+        literal = ipaddress.ip_address(host)
+    except ValueError:
+        def _resolve():
+            return socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+
+        infos = await asyncio.to_thread(_resolve)
+        addresses: set[ipaddress.IPv4Address | ipaddress.IPv6Address] = set()
+        for info in infos:
+            try:
+                addresses.add(ipaddress.ip_address(info[4][0]))
+            except ValueError:
+                continue
+        return sorted(addresses, key=lambda addr: (addr.version != 4, str(addr)))
+    return [literal]
+
+
+async def _public_target(url: str) -> tuple[str, str] | None:
+    """Return ``(hostname, pinned_ip)`` for a safe manual URL, else ``None``."""
+    try:
+        parsed = urlparse((url or "").strip())
+        if parsed.scheme != "https" or not parsed.hostname:
+            return None
+        if parsed.username is not None or parsed.password is not None:
+            return None
+        port = parsed.port or 443
+        addresses = await _resolve_addresses(parsed.hostname, port)
+    except (OSError, socket.gaierror, UnicodeError, ValueError):
+        return None
+
+    # Reject mixed public/private answers rather than selecting the convenient
+    # one. That keeps split-horizon and rebinding-style answers out entirely.
+    if not addresses or not all(_is_public(address) for address in addresses):
+        return None
+    return parsed.hostname, str(addresses[0])
+
+
+async def _fetch_once(url: str) -> tuple[int, str | None, bytes | None] | None:
+    """Fetch one URL hop after pinning its validated public DNS result."""
+    target = await _public_target(url)
+    if target is None:
+        return None
+    hostname, address = target
+
+    await outbound.acquire(hostname)
+    transport = _PinnedIPTransport(address)
+    try:
+        async with httpx.AsyncClient(
+            transport=transport,
+            timeout=HTTP_TIMEOUT,
+            follow_redirects=False,
+        ) as client:
+            async with client.stream("GET", url) as resp:
+                location = resp.headers.get("location")
+                if resp.status_code in _REDIRECT_STATUSES:
+                    return resp.status_code, location, None
+                if resp.status_code != 200:
+                    return resp.status_code, None, None
+
+                raw_length = resp.headers.get("content-length")
+                if raw_length:
+                    try:
+                        if int(raw_length) > covers.MAX_COVER_SIZE:
+                            return resp.status_code, None, None
+                    except ValueError:
+                        pass
+
+                content = bytearray()
+                async for chunk in resp.aiter_bytes():
+                    if len(content) + len(chunk) > covers.MAX_COVER_SIZE:
+                        return resp.status_code, None, None
+                    content.extend(chunk)
+                return resp.status_code, None, bytes(content)
+    except (httpx.HTTPError, OSError):
+        logger.debug("Manual cover download failed for %s", url, exc_info=True)
+        return None
+
+
+async def download(item_id: int, url: str) -> str | None:
+    """Download a public HTTPS image into Shelf and return its relative path."""
+    current = (url or "").strip()
+    for _ in range(_MAX_REDIRECTS + 1):
+        result = await _fetch_once(current)
+        if result is None:
+            return None
+        status, location, content = result
+        if status in _REDIRECT_STATUSES:
+            if not location:
+                return None
+            current = urljoin(current, location)
+            continue
+        if status != 200 or content is None:
+            return None
+        if len(content) < covers.MIN_COVER_SIZE or not covers._looks_like_image(content):
+            return None
+
+        COVERS_DIR.mkdir(parents=True, exist_ok=True)
+        (COVERS_DIR / f"{item_id}.jpg").write_bytes(content)
+        return f"covers/{item_id}.jpg"
+    return None

--- a/app/templates/fragments/cover_search.html
+++ b/app/templates/fragments/cover_search.html
@@ -57,18 +57,38 @@
     {% endif %}
     {% endif %}
 
-    <div class="mt-3 space-y-2">
-        <form hx-post="/api/items/{{ item_id }}/cover-upload" hx-swap="none" enctype="multipart/form-data"
-              data-testid="cover-upload"
-              hx-disabled-elt="find input[type=file], find button"
-              class="flex flex-wrap items-center gap-2">
-            <input type="file" name="cover" accept="image/*"
-                   class="block w-full min-w-0 text-sm text-shelf-muted file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-sm file:bg-shelf-hover file:text-shelf-text">
-            <button type="submit"
-                    class="px-3 py-1.5 bg-shelf-hover text-shelf-text rounded-lg text-sm hover:bg-shelf-border transition-colors whitespace-nowrap">
-                Upload
-            </button>
-        </form>
+    <div class="mt-3 space-y-3">
+        <div>
+            <p class="text-xs font-medium text-shelf-muted mb-1">Use image from URL</p>
+            <form hx-post="/api/items/{{ item_id }}/cover-url" hx-swap="none"
+                  data-testid="cover-url"
+                  hx-disabled-elt="find input, find button"
+                  class="flex items-center gap-2">
+                <input type="url" name="url" required inputmode="url" autocomplete="url"
+                       placeholder="https://example.com/cover.jpg"
+                       class="min-w-0 flex-1 bg-shelf-bg border border-shelf-border rounded-lg px-2 py-1.5 text-sm text-shelf-text focus:ring-2 focus:ring-shelf-accent focus:border-transparent outline-none placeholder-shelf-muted/50">
+                <button type="submit"
+                        class="px-3 py-1.5 bg-shelf-hover text-shelf-text rounded-lg text-sm hover:bg-shelf-border transition-colors whitespace-nowrap">
+                    Use image
+                </button>
+            </form>
+            <p class="text-xs text-shelf-muted mt-1">Public HTTPS image links only. Shelf saves its own local copy.</p>
+        </div>
+
+        <div>
+            <p class="text-xs font-medium text-shelf-muted mb-1">Upload from this device</p>
+            <form hx-post="/api/items/{{ item_id }}/cover-upload" hx-swap="none" enctype="multipart/form-data"
+                  data-testid="cover-upload"
+                  hx-disabled-elt="find input[type=file], find button"
+                  class="flex flex-wrap items-center gap-2">
+                <input type="file" name="cover" accept="image/jpeg,image/png,image/gif,image/webp"
+                       class="block w-full min-w-0 text-sm text-shelf-muted file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-sm file:bg-shelf-hover file:text-shelf-text">
+                <button type="submit"
+                        class="px-3 py-1.5 bg-shelf-hover text-shelf-text rounded-lg text-sm hover:bg-shelf-border transition-colors whitespace-nowrap">
+                    Upload
+                </button>
+            </form>
+        </div>
         {% if cover_path %}
         <button hx-post="/api/items/{{ item_id }}/cover-remove" hx-swap="none" hx-confirm="Remove this cover?"
                 data-testid="cover-remove"

--- a/tests/test_manual_cover_url.py
+++ b/tests/test_manual_cover_url.py
@@ -1,0 +1,163 @@
+"""Manual cover URL route and public-network boundary."""
+
+import asyncio
+import ipaddress
+from unittest.mock import AsyncMock
+
+import httpx
+
+from app.services import provider_result
+from tests.conftest import _insert_item
+
+
+def test_cover_picker_exposes_manual_url(editor_client, db, monkeypatch):
+    from app.services import covers
+
+    item_id = _insert_item(db, title="Manual cover", isbn="9780900011001")
+    db.commit()
+    monkeypatch.setattr(
+        covers,
+        "search_covers",
+        AsyncMock(return_value=provider_result.found("openlibrary", [])),
+    )
+
+    resp = editor_client.get(f"/api/items/{item_id}/cover-search")
+
+    assert resp.status_code == 200
+    assert 'data-testid="cover-url"' in resp.text
+    assert f'hx-post="/api/items/{item_id}/cover-url"' in resp.text
+    assert "Public HTTPS image links only" in resp.text
+
+
+def test_manual_url_updates_cover(editor_client, db, monkeypatch):
+    from app.services import manual_cover
+
+    item_id = _insert_item(db, title="Manual cover", isbn="9780900011002")
+    db.commit()
+    download = AsyncMock(return_value=f"covers/{item_id}.jpg")
+    monkeypatch.setattr(manual_cover, "download", download)
+
+    resp = editor_client.post(
+        f"/api/items/{item_id}/cover-url",
+        data={"url": "https://images.example.test/cover.jpg"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.headers.get("HX-Redirect") == f"/item/{item_id}"
+    row = db.execute("SELECT cover_path FROM items WHERE id = ?", (item_id,)).fetchone()
+    assert row["cover_path"] == f"covers/{item_id}.jpg"
+    download.assert_awaited_once_with(item_id, "https://images.example.test/cover.jpg")
+
+
+def test_failed_manual_url_keeps_existing_cover(editor_client, db, monkeypatch):
+    from app.services import manual_cover
+
+    item_id = _insert_item(
+        db,
+        title="Keep cover",
+        isbn="9780900011003",
+        cover_path="covers/existing.jpg",
+    )
+    db.commit()
+    monkeypatch.setattr(manual_cover, "download", AsyncMock(return_value=None))
+
+    resp = editor_client.post(
+        f"/api/items/{item_id}/cover-url",
+        data={"url": "https://images.example.test/not-an-image"},
+    )
+
+    assert resp.status_code == 200
+    assert "HX-Redirect" not in resp.headers
+    assert "error" in resp.headers.get("HX-Trigger", "")
+    row = db.execute("SELECT cover_path FROM items WHERE id = ?", (item_id,)).fetchone()
+    assert row["cover_path"] == "covers/existing.jpg"
+
+
+def test_manual_url_unknown_item_is_404(editor_client):
+    resp = editor_client.post(
+        "/api/items/999999/cover-url",
+        data={"url": "https://images.example.test/cover.jpg"},
+    )
+    assert resp.status_code == 404
+
+
+def test_manual_url_requires_editor(viewer_client, db):
+    item_id = _insert_item(db, title="Viewer cover", isbn="9780900011004")
+    db.commit()
+    resp = viewer_client.post(
+        f"/api/items/{item_id}/cover-url",
+        data={"url": "https://images.example.test/cover.jpg"},
+    )
+    assert resp.status_code in (401, 403)
+
+
+def test_http_credentials_and_private_targets_are_rejected(monkeypatch):
+    from app.services import manual_cover
+
+    async def resolve_private(_host, _port):
+        return [ipaddress.ip_address("10.0.0.5")]
+
+    monkeypatch.setattr(manual_cover, "_resolve_addresses", resolve_private)
+
+    async def run():
+        assert await manual_cover._public_target("http://example.com/a.jpg") is None
+        assert await manual_cover._public_target("https://user:pass@example.com/a.jpg") is None
+        assert await manual_cover._public_target("https://example.com/a.jpg") is None
+        assert await manual_cover._public_target("https://127.0.0.1/a.jpg") is None
+
+    asyncio.run(run())
+
+
+def test_mixed_public_private_dns_answer_is_rejected(monkeypatch):
+    from app.services import manual_cover
+
+    async def resolve(_host, _port):
+        return [ipaddress.ip_address("8.8.8.8"), ipaddress.ip_address("192.168.1.10")]
+
+    monkeypatch.setattr(manual_cover, "_resolve_addresses", resolve)
+    assert asyncio.run(manual_cover._public_target("https://covers.example.test/a.jpg")) is None
+
+
+def test_public_dns_answer_is_pinned_for_the_actual_request():
+    from app.services.manual_cover import _PinnedIPTransport
+
+    seen = {}
+
+    async def handler(request: httpx.Request):
+        seen["url"] = str(request.url)
+        seen["host"] = request.headers["host"]
+        seen["sni"] = request.extensions.get("sni_hostname")
+        return httpx.Response(200, content=b"ok", request=request)
+
+    async def run():
+        transport = _PinnedIPTransport(
+            "203.0.113.10",
+            transport=httpx.MockTransport(handler),
+        )
+        async with httpx.AsyncClient(transport=transport) as client:
+            await client.get("https://covers.example.test/image.jpg")
+
+    asyncio.run(run())
+
+    assert seen["url"] == "https://203.0.113.10/image.jpg"
+    assert seen["host"] == "covers.example.test"
+    assert seen["sni"] == "covers.example.test"
+
+
+def test_redirect_target_is_validated_as_a_new_hop(monkeypatch):
+    from app.services import manual_cover
+
+    calls = []
+
+    async def fetch(url):
+        calls.append(url)
+        if len(calls) == 1:
+            return 302, "https://127.0.0.1/private.jpg", None
+        return None
+
+    monkeypatch.setattr(manual_cover, "_fetch_once", fetch)
+    assert asyncio.run(manual_cover.download(1, "https://covers.example.test/start.jpg")) is None
+    assert calls == [
+        "https://covers.example.test/start.jpg",
+        "https://127.0.0.1/private.jpg",
+    ]


### PR DESCRIPTION
## What this changes

Adds a **Use image from URL** option to the existing cover picker.

- accepts a user-supplied public HTTPS image URL;
- downloads and stores Shelf's own local copy rather than hotlinking;
- keeps the existing cover unchanged if the download or image validation fails;
- requires Editor access, matching the existing cover controls;
- rejects private/local/mixed DNS destinations;
- pins the HTTPS connection to the validated public address while preserving the original hostname for TLS/SNI and Host validation;
- validates every redirect again, with a five-redirect limit;
- streams responses under Shelf's existing 10 MB cover ceiling and existing JPEG/PNG/GIF/WebP validation.

Fixes #91.

## Why

The correct cover for a particular edition, pressing or issue is sometimes available online but not returned by Shelf's metadata providers. Today the image has to be downloaded manually and then uploaded to Shelf.

This keeps that workflow inside the existing cover picker while treating a pasted URL as untrusted network input.

## How it was tested

GitHub Actions validation run #829 passed on the exact contribution branch:

- [x] `make test` passes
- [x] `make test-e2e` passes
- [ ] `make checks` passes
- [x] `make css` re-run, if templates or Tailwind classes changed

The CI offline secret/CSRF/Alpine checks also pass. I have not marked the full `make checks` target because the validation workflow runs its offline lint subset rather than the network-dependent dependency audit.

Focused tests cover public/private DNS handling, mixed answers, redirect revalidation, pinned TLS/Host behaviour, content type/signature and size limits, failed-download preservation, Editor permissions and successful local persistence.

## Notes for review

This is deliberately isolated from the larger fork: no schema changes, no library/ACL dependencies and no unrelated editor work.

The manual-URL path does not reuse provider cover downloading directly because provider URLs are trusted application inputs whereas this endpoint accepts arbitrary user-supplied network destinations. The separate helper keeps that SSRF boundary explicit.
