### PR TITLE
Track first-class physical copies of catalogue items

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -147,6 +147,29 @@ MIGRATIONS: Sequence[tuple[int, str, str]] = (
                   AND isbn13 NOT GLOB '*[^0-9]*'
                   AND substr(isbn13, 1, 3) IN ('978', '979'))
         )"""),
+    (25, "Add first-class physical copies",
+     """CREATE TABLE IF NOT EXISTS item_copies (
+            id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+            item_id            INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+            copy_number        INTEGER NOT NULL,
+            location_id        INTEGER REFERENCES locations(id) ON DELETE SET NULL,
+            condition          TEXT,
+            notes              TEXT,
+            acquired_date      TEXT,
+            acquisition_source TEXT,
+            acquisition_price  REAL CHECK(acquisition_price IS NULL OR acquisition_price >= 0),
+            provenance         TEXT,
+            copy_barcode       TEXT UNIQUE,
+            is_primary         INTEGER NOT NULL DEFAULT 0 CHECK(is_primary IN (0, 1)),
+            created_at         TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at         TEXT NOT NULL DEFAULT (datetime('now')),
+            UNIQUE(item_id, copy_number)
+        )"""),
+    (26, "Backfill primary copies from legacy locations",
+     """INSERT INTO item_copies (item_id, copy_number, location_id, is_primary)
+        SELECT i.id, 1, i.location_id, 1 FROM items i
+        WHERE i.owned = 1 AND i.location_id IS NOT NULL
+          AND NOT EXISTS (SELECT 1 FROM item_copies c WHERE c.item_id = i.id)"""),
 )
 
 MIGRATION_TABLES = """
@@ -195,6 +218,28 @@ CREATE TABLE IF NOT EXISTS checkouts (
 );
 CREATE INDEX IF NOT EXISTS idx_checkouts_item ON checkouts(item_id);
 CREATE INDEX IF NOT EXISTS idx_checkouts_borrower ON checkouts(borrower_id);
+
+CREATE TABLE IF NOT EXISTS item_copies (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    item_id            INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    copy_number        INTEGER NOT NULL,
+    location_id        INTEGER REFERENCES locations(id) ON DELETE SET NULL,
+    condition          TEXT,
+    notes              TEXT,
+    acquired_date      TEXT,
+    acquisition_source TEXT,
+    acquisition_price  REAL CHECK(acquisition_price IS NULL OR acquisition_price >= 0),
+    provenance         TEXT,
+    copy_barcode       TEXT UNIQUE,
+    is_primary         INTEGER NOT NULL DEFAULT 0 CHECK(is_primary IN (0, 1)),
+    created_at         TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at         TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(item_id, copy_number)
+);
+CREATE INDEX IF NOT EXISTS idx_item_copies_item ON item_copies(item_id, copy_number);
+CREATE INDEX IF NOT EXISTS idx_item_copies_location ON item_copies(location_id, item_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_item_copies_one_primary
+    ON item_copies(item_id) WHERE is_primary = 1;
 
 CREATE INDEX IF NOT EXISTS idx_items_upc ON items(upc);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_items_upc_type ON items(upc, media_type) WHERE upc IS NOT NULL;
@@ -308,7 +353,7 @@ def _is_benign_migration_error(version: int, exc: sqlite3.OperationalError) -> b
     match = re.search(r"no such table: (?:\w+\.)?(\w+)", msg)
     if match:
         # G1: every MIGRATION_TABLES CREATE bakes in the columns its ALTERs
-        # add, and it runs after the migration loop — so for the tables it
+        # add, and it runs after the MIGRATIONS loop — so for the tables it
         # manages the ALTER is redundant by design and recording the version
         # is correct. A table it will not create is a typo or a removed
         # table; recording that would make the divergence permanent.

--- a/app/database.py
+++ b/app/database.py
@@ -170,6 +170,14 @@ MIGRATIONS: Sequence[tuple[int, str, str]] = (
         SELECT i.id, 1, i.location_id, 1 FROM items i
         WHERE i.owned = 1 AND i.location_id IS NOT NULL
           AND NOT EXISTS (SELECT 1 FROM item_copies c WHERE c.item_id = i.id)"""),
+    (27, "Add parent relationship to locations",
+     "ALTER TABLE locations ADD COLUMN parent_id INTEGER REFERENCES locations(id) ON DELETE RESTRICT"),
+    (28, "Add node label to locations",
+     "ALTER TABLE locations ADD COLUMN label TEXT DEFAULT NULL"),
+    (29, "Backfill flat locations as hierarchy roots",
+     "UPDATE locations SET label = name WHERE label IS NULL"),
+    (30, "Index hierarchical location children",
+     "CREATE INDEX IF NOT EXISTS idx_locations_parent ON locations(parent_id, sort_order)"),
 )
 
 MIGRATION_TABLES = """

--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -1,10 +1,10 @@
-import sqlite3
-
 from fastapi import APIRouter, Depends, Form
 from fastapi.responses import RedirectResponse
 
 from app.auth import require_role
 from app.database import get_db
+from app.services import item_copies
+from app.services import locations as location_svc
 
 router = APIRouter(prefix="/api/locations", dependencies=[Depends(require_role("admin"))])
 
@@ -14,57 +14,88 @@ def _settings_error(code: str) -> RedirectResponse:
     return RedirectResponse(url=f"/settings?location_error={code}", status_code=303)
 
 
-@router.post("")
-async def create_location(name: str = Form(...), sort_order: int = Form(0)):
-    name = name.strip()
-    if not name:
-        return _settings_error("blank")
+def _parent_id(value: int | None) -> int | None:
+    return value if value not in (None, 0) else None
 
+
+@router.post("")
+async def create_location(
+    name: str = Form(...),
+    sort_order: int = Form(0),
+    parent_id: int | None = Form(None),
+):
     try:
         with get_db() as db:
-            db.execute(
-                "INSERT INTO locations (name, sort_order) VALUES (?, ?)",
-                (name, sort_order),
+            location_svc.create_location(
+                db,
+                name,
+                parent_id=_parent_id(parent_id),
+                sort_order=sort_order,
             )
-    except sqlite3.IntegrityError:
-        # `locations.name` is UNIQUE. Convert a stale/duplicate form submit to
-        # a normal Settings error instead of leaking a database exception.
+    except location_svc.DuplicateLocation:
         return _settings_error("duplicate")
+    except location_svc.LocationNotFound:
+        return _settings_error("parent_missing")
+    except location_svc.LocationError:
+        return _settings_error("blank")
 
     return RedirectResponse(url="/settings", status_code=303)
 
 
 @router.post("/{location_id}/update")
-async def update_location(location_id: int, name: str = Form(...), sort_order: int = Form(0)):
-    name = name.strip()
-    if not name:
-        return _settings_error("blank")
-
+async def update_location(
+    location_id: int,
+    name: str = Form(...),
+    sort_order: int = Form(0),
+    parent_id: int | None = Form(None),
+):
     try:
         with get_db() as db:
-            exists = db.execute(
-                "SELECT 1 FROM locations WHERE id = ?", (location_id,)
-            ).fetchone()
-            if not exists:
-                return _settings_error("missing")
-            db.execute(
-                "UPDATE locations SET name = ?, sort_order = ? WHERE id = ?",
-                (name, sort_order, location_id),
+            location_svc.update_location(
+                db,
+                location_id,
+                name,
+                parent_id=_parent_id(parent_id),
+                sort_order=sort_order,
             )
-    except sqlite3.IntegrityError:
+    except location_svc.DuplicateLocation:
         return _settings_error("duplicate")
+    except location_svc.InvalidLocationParent:
+        return _settings_error("invalid_parent")
+    except location_svc.LocationNotFound:
+        return _settings_error("missing")
+    except location_svc.LocationError:
+        return _settings_error("blank")
 
     return RedirectResponse(url="/settings", status_code=303)
 
 
 @router.post("/{location_id}/delete")
 async def delete_location(location_id: int):
-    with get_db() as db:
-        exists = db.execute(
-            "SELECT 1 FROM locations WHERE id = ?", (location_id,)
-        ).fetchone()
-        if not exists:
-            return _settings_error("missing")
-        db.execute("UPDATE items SET location_id = NULL WHERE location_id = ?", (location_id,))
-        db.execute("DELETE FROM locations WHERE id = ?", (location_id,))
+    try:
+        with get_db() as db:
+            # Keep Shelf's long-standing system cascade explicit at the route
+            # boundary (and therefore inside the existing raw-update allowlist).
+            # #97 adds a primary-copy compatibility projection, so mirror that
+            # clear for affected primary copies before the location row goes.
+            item_ids = [
+                row["id"] for row in db.execute(
+                    "SELECT id FROM items WHERE location_id = ?", (location_id,)
+                ).fetchall()
+            ]
+            db.execute(
+                "UPDATE items SET location_id = NULL WHERE location_id = ?",
+                (location_id,),
+            )
+            for item_id in item_ids:
+                item_copies.sync_primary_location(db, item_id, None)
+
+            # Direct service callers still use the item-write funnel; here the
+            # route cascade has already cleared those rows, so this validates
+            # child safety and deletes the leaf without a second item update.
+            location_svc.delete_location(db, location_id)
+    except location_svc.LocationHasChildren:
+        return _settings_error("has_children")
+    except location_svc.LocationNotFound:
+        return _settings_error("missing")
     return RedirectResponse(url="/settings", status_code=303)

--- a/app/services/item_copies.py
+++ b/app/services/item_copies.py
@@ -1,0 +1,83 @@
+"""Physical-copy compatibility helpers for upstream issue #97.
+
+Shelf's catalogue row remains the shared descriptive record. ``item_copies``
+represents individual physical objects and deliberately does not infer whether
+a media type is physical or digital.
+
+During the transition, ``items.location_id`` remains the compatibility field
+used by the existing UI. The primary copy mirrors that value when one exists;
+secondary copies are never moved by legacy item writes.
+"""
+
+
+def backfill_legacy_locations(db) -> int:
+    """Create one primary copy for legacy rows that prove a physical place.
+
+    ``owned`` by itself is not sufficient evidence: Shelf can mark digital
+    service-backed items as owned. An owned item with an explicit legacy
+    location is conservative evidence that Shelf already treats the row as a
+    placed physical object. The operation is idempotent.
+    """
+    before = db.total_changes
+    db.execute(
+        "INSERT INTO item_copies (item_id, copy_number, location_id, is_primary) "
+        "SELECT i.id, 1, i.location_id, 1 FROM items i "
+        "WHERE i.owned = 1 AND i.location_id IS NOT NULL "
+        "AND NOT EXISTS (SELECT 1 FROM item_copies c WHERE c.item_id = i.id)"
+    )
+    return db.total_changes - before
+
+
+def sync_primary_location(db, item_id: int, location_id: int | None) -> int | None:
+    """Mirror the legacy item location into the primary physical copy.
+
+    A non-null location creates the first primary copy if none exists. Clearing
+    a location never invents a copy merely to store ``NULL``. Existing
+    secondary copies are untouched.
+
+    Returns the primary copy id, or ``None`` when no copy exists or is needed.
+    """
+    if location_id is not None and not db.execute(
+        "SELECT 1 FROM locations WHERE id = ?", (location_id,)
+    ).fetchone():
+        raise ValueError("Location not found")
+
+    primary = db.execute(
+        "SELECT id FROM item_copies WHERE item_id = ? AND is_primary = 1",
+        (item_id,),
+    ).fetchone()
+    if primary:
+        db.execute(
+            "UPDATE item_copies SET location_id = ?, updated_at = datetime('now') "
+            "WHERE id = ?",
+            (location_id, primary["id"]),
+        )
+        return primary["id"]
+
+    if location_id is None:
+        return None
+
+    item = db.execute("SELECT 1 FROM items WHERE id = ?", (item_id,)).fetchone()
+    if not item:
+        raise ValueError("Item not found")
+
+    next_number = db.execute(
+        "SELECT COALESCE(MAX(copy_number), 0) + 1 AS n FROM item_copies WHERE item_id = ?",
+        (item_id,),
+    ).fetchone()["n"]
+    cursor = db.execute(
+        "INSERT INTO item_copies (item_id, copy_number, location_id, is_primary) "
+        "VALUES (?, ?, ?, 1)",
+        (item_id, next_number, location_id),
+    )
+    return cursor.lastrowid
+
+
+def copies_for_item(db, item_id: int):
+    """Return physical copies in stable user-facing order."""
+    return db.execute(
+        "SELECT c.*, l.name AS location_name FROM item_copies c "
+        "LEFT JOIN locations l ON l.id = c.location_id "
+        "WHERE c.item_id = ? ORDER BY c.copy_number, c.id",
+        (item_id,),
+    ).fetchall()

--- a/app/services/item_write.py
+++ b/app/services/item_write.py
@@ -33,6 +33,13 @@ Hardcover ids, the `location_id = NULL` cascades, name-keyed series writes)
 still use a raw `UPDATE items SET`; `tests/test_item_write.py` allowlists
 those and fails on any other.
 
+`items.location_id` is also the compatibility seam for first-class physical
+copies (#97). When a normal item write supplies that field, the write funnel
+mirrors it into the item's primary copy after the item statement succeeds.
+A null location never invents a copy, and secondary copies are never moved by
+the legacy field. This keeps every existing add/edit/import surface working
+while copy-specific UI can be introduced separately.
+
 A field that is not present is not validated: an update that touches only
 `notes` never reads `isbn`. Callers that hold a *provider's* value (an
 Audiobookshelf ASIN, a Hardcover edition ISBN) pre-clean it with
@@ -51,6 +58,7 @@ from typing import Any, Iterable, Mapping
 from app.config import MEDIA_TYPES
 from app.database import get_game_platforms
 from app.services import isbn as isbn_svc
+from app.services import item_copies
 from app.services.write_targets import (  # noqa: F401 — re-exported
     ItemValueError,
     UnknownLocationError,
@@ -271,14 +279,19 @@ def insert_item(db, fields: Mapping[str, Any] | None = None, **kwargs) -> int:
         f"INSERT INTO items ({', '.join(names)}) VALUES ({placeholders})",
         [values[n] for n in names],
     )
-    return cursor.lastrowid
+    item_id = cursor.lastrowid
+    if "location_id" in values:
+        item_copies.sync_primary_location(db, item_id, values["location_id"])
+    return item_id
 
 
 def _execute_update(db, fields: Mapping[str, Any], where: str,
-                    where_params: list[Any], who: str) -> None:
+                    where_params: list[Any], who: str) -> dict[str, Any]:
     """Validate names and values, then run the one UPDATE this module holds.
 
     `updated_at` is always stamped, so an empty `fields` is a bare touch.
+    Returns the normalised values so compatibility projections can use exactly
+    what was written rather than re-parsing the caller's raw input.
     """
     values = dict(fields)
     values.pop("updated_at", None)
@@ -290,6 +303,7 @@ def _execute_update(db, fields: Mapping[str, Any], where: str,
         f"UPDATE items SET {', '.join(assignments)} WHERE {where}",
         [*(values[n] for n in values), *where_params],
     )
+    return values
 
 
 def update_item_fields(db, item_id: int, fields: Mapping[str, Any]) -> None:
@@ -299,7 +313,11 @@ def update_item_fields(db, item_id: int, fields: Mapping[str, Any]) -> None:
     `created_at`); always stamps `updated_at`. Raises `ItemValueError` on a
     bad value, `ValueError` on a bad name.
     """
-    _execute_update(db, fields, "id = ?", [item_id], "update_item_fields")
+    values = _execute_update(db, fields, "id = ?", [item_id], "update_item_fields")
+    if "location_id" in values and db.execute(
+        "SELECT 1 FROM items WHERE id = ?", (item_id,)
+    ).fetchone():
+        item_copies.sync_primary_location(db, item_id, values["location_id"])
 
 
 def update_items_fields(db, item_ids: Iterable[int],
@@ -309,4 +327,12 @@ def update_items_fields(db, item_ids: Iterable[int],
     if not ids:
         return
     marks = ", ".join("?" for _ in ids)
-    _execute_update(db, fields, f"id IN ({marks})", ids, "update_items_fields")
+    values = _execute_update(db, fields, f"id IN ({marks})", ids, "update_items_fields")
+    if "location_id" in values:
+        existing_ids = [
+            row["id"] for row in db.execute(
+                f"SELECT id FROM items WHERE id IN ({marks})", ids
+            ).fetchall()
+        ]
+        for item_id in existing_ids:
+            item_copies.sync_primary_location(db, item_id, values["location_id"])

--- a/app/services/locations.py
+++ b/app/services/locations.py
@@ -1,0 +1,204 @@
+"""Hierarchical physical-location helpers (upstream issue #98).
+
+`locations.name` remains Shelf's backwards-compatible display value and stores
+the full path. `label` is the node's own name and `parent_id` carries the
+actual hierarchy. Keeping the denormalised full path means existing item,
+archive, browse and select-box code continues to show an unambiguous location
+without every caller needing to understand the tree at once.
+"""
+
+import sqlite3
+
+
+class LocationError(ValueError):
+    """Base class for location-tree validation failures."""
+
+
+class LocationNotFound(LocationError):
+    pass
+
+
+class DuplicateLocation(LocationError):
+    pass
+
+
+class InvalidLocationParent(LocationError):
+    pass
+
+
+class LocationHasChildren(LocationError):
+    pass
+
+
+def _node_label(row) -> str:
+    """Return a migrated node label, falling back for legacy/raw inserts."""
+    return row["label"] or row["name"]
+
+
+def _row(db, location_id: int):
+    row = db.execute(
+        "SELECT id, name, label, parent_id, sort_order FROM locations WHERE id = ?",
+        (location_id,),
+    ).fetchone()
+    if not row:
+        raise LocationNotFound("Location not found")
+    return row
+
+
+def _parent(db, parent_id: int | None):
+    if parent_id is None:
+        return None
+    return _row(db, parent_id)
+
+
+def _full_name(parent, label: str) -> str:
+    return f"{parent['name']} / {label}" if parent else label
+
+
+def _duplicate_exists(db, label: str, parent_id: int | None,
+                      *, exclude_id: int | None = None) -> bool:
+    sql = (
+        "SELECT 1 FROM locations "
+        "WHERE parent_id IS ? "
+        "AND lower(COALESCE(label, name)) = lower(?)"
+    )
+    params: list[object] = [parent_id, label]
+    if exclude_id is not None:
+        sql += " AND id <> ?"
+        params.append(exclude_id)
+    return db.execute(sql, params).fetchone() is not None
+
+
+def _assert_parent_not_in_subtree(db, location_id: int,
+                                  parent_id: int | None) -> None:
+    if parent_id is None:
+        return
+    if parent_id == location_id:
+        raise InvalidLocationParent("A location cannot be its own parent")
+
+    in_subtree = db.execute(
+        "WITH RECURSIVE subtree(id) AS ("
+        "  SELECT id FROM locations WHERE id = ? "
+        "  UNION ALL "
+        "  SELECT l.id FROM locations l JOIN subtree s ON l.parent_id = s.id"
+        ") SELECT 1 FROM subtree WHERE id = ?",
+        (location_id, parent_id),
+    ).fetchone()
+    if in_subtree:
+        raise InvalidLocationParent("A location cannot be moved inside itself")
+
+
+def create_location(db, label: str, *, parent_id: int | None = None,
+                    sort_order: int = 0) -> int:
+    """Create one location node and return its id."""
+    label = label.strip()
+    if not label:
+        raise LocationError("Location name cannot be blank")
+
+    parent = _parent(db, parent_id)
+    if _duplicate_exists(db, label, parent_id):
+        raise DuplicateLocation("A location with that name already exists here")
+
+    try:
+        cursor = db.execute(
+            "INSERT INTO locations (name, label, parent_id, sort_order) "
+            "VALUES (?, ?, ?, ?)",
+            (_full_name(parent, label), label, parent_id, sort_order),
+        )
+    except sqlite3.IntegrityError as exc:
+        raise DuplicateLocation("A location with that name already exists here") from exc
+    return cursor.lastrowid
+
+
+def _rewrite_descendant_paths(db, parent_id: int) -> None:
+    """Rebuild denormalised names below a renamed or moved node."""
+    parent = _row(db, parent_id)
+    children = db.execute(
+        "SELECT id, name, label, parent_id, sort_order FROM locations "
+        "WHERE parent_id = ? ORDER BY sort_order, lower(COALESCE(label, name)), id",
+        (parent_id,),
+    ).fetchall()
+    for child in children:
+        label = _node_label(child)
+        db.execute(
+            "UPDATE locations SET name = ?, label = ? WHERE id = ?",
+            (_full_name(parent, label), label, child["id"]),
+        )
+        _rewrite_descendant_paths(db, child["id"])
+
+
+def update_location(db, location_id: int, label: str, *,
+                    parent_id: int | None = None, sort_order: int = 0) -> None:
+    """Rename/reparent one node and update every descendant's full path."""
+    label = label.strip()
+    if not label:
+        raise LocationError("Location name cannot be blank")
+
+    _row(db, location_id)
+    parent = _parent(db, parent_id)
+    _assert_parent_not_in_subtree(db, location_id, parent_id)
+    if _duplicate_exists(db, label, parent_id, exclude_id=location_id):
+        raise DuplicateLocation("A location with that name already exists here")
+
+    try:
+        db.execute(
+            "UPDATE locations SET name = ?, label = ?, parent_id = ?, sort_order = ? "
+            "WHERE id = ?",
+            (_full_name(parent, label), label, parent_id, sort_order, location_id),
+        )
+        _rewrite_descendant_paths(db, location_id)
+    except sqlite3.IntegrityError as exc:
+        raise DuplicateLocation("A location with that name already exists here") from exc
+
+
+def delete_location(db, location_id: int) -> None:
+    """Delete a leaf location; parents must be emptied/moved deliberately."""
+    _row(db, location_id)
+    if db.execute(
+        "SELECT 1 FROM locations WHERE parent_id = ? LIMIT 1", (location_id,)
+    ).fetchone():
+        raise LocationHasChildren("Move or remove child locations first")
+
+    # Preserve the single item-write funnel while clearing the legacy
+    # compatibility projection. This also clears the primary copy through
+    # item_write's #97 compatibility hook. Secondary copies are then cleared
+    # by item_copies.location_id's ON DELETE SET NULL foreign key below.
+    item_ids = [
+        row["id"] for row in db.execute(
+            "SELECT id FROM items WHERE location_id = ?", (location_id,)
+        ).fetchall()
+    ]
+    if item_ids:
+        from app.services.item_write import update_items_fields
+        update_items_fields(db, item_ids, {"location_id": None})
+
+    db.execute("DELETE FROM locations WHERE id = ?", (location_id,))
+
+
+def location_tree(db):
+    """Return all nodes in stable depth-first order with a computed depth."""
+    rows = db.execute(
+        "SELECT id, name, label, parent_id, sort_order FROM locations"
+    ).fetchall()
+    by_parent: dict[int | None, list] = {}
+    for row in rows:
+        by_parent.setdefault(row["parent_id"], []).append(row)
+    for children in by_parent.values():
+        children.sort(key=lambda r: (r["sort_order"], _node_label(r).casefold(), r["id"]))
+
+    out: list[dict] = []
+
+    def visit(parent_id: int | None, depth: int) -> None:
+        for row in by_parent.get(parent_id, []):
+            out.append({
+                "id": row["id"],
+                "name": row["name"],
+                "label": _node_label(row),
+                "parent_id": row["parent_id"],
+                "sort_order": row["sort_order"],
+                "depth": depth,
+            })
+            visit(row["id"], depth + 1)
+
+    visit(None, 0)
+    return out

--- a/app/templates/fragments/settings/library.html
+++ b/app/templates/fragments/settings/library.html
@@ -85,26 +85,71 @@
     <!-- Locations -->
     <div class="bg-shelf-card rounded-xl border border-shelf-border p-6">
         <h2 class="text-lg font-semibold mb-4">Locations</h2>
+        <p class="text-sm text-shelf-muted mb-4">Locations can be nested to whatever depth your collection needs, for example Living Room → Bookcase 1 → Shelf 3. A parent can also be used as a location itself.</p>
+
+        {% set location_error = request.query_params.get('location_error') %}
+        {% if location_error in ('parent_missing', 'invalid_parent', 'has_children') %}
+        <div data-testid="location-tree-error-banner"
+             class="bg-shelf-bg text-shelf-error border border-shelf-border rounded-lg px-4 py-2 text-sm mb-4">
+            {% if location_error == 'parent_missing' %}The selected parent location no longer exists.{% endif %}
+            {% if location_error == 'invalid_parent' %}A location cannot be moved inside itself or one of its children.{% endif %}
+            {% if location_error == 'has_children' %}Move or remove this location's child locations before deleting it.{% endif %}
+        </div>
+        {% endif %}
 
         {% if locations %}
         <div class="space-y-2 mb-4">
             {% for loc in locations %}
-            <div class="flex flex-wrap items-center justify-between gap-2 bg-shelf-bg rounded-lg px-4 py-2">
-                <span>{{ loc.name }}</span>
-                <form action="/api/locations/{{ loc.id }}/delete" method="post" class="inline"
-                      data-confirm="Delete location '{{ loc.name }}'?">
-                    <button type="submit" class="text-shelf-muted hover:text-shelf-error text-sm transition-colors">
-                        Remove
-                    </button>
-                </form>
+            <div class="bg-shelf-bg rounded-lg px-4 py-2" data-testid="location-row-{{ loc.id }}">
+                <div class="flex flex-wrap items-center justify-between gap-2">
+                    <span>{{ loc.name }}</span>
+                    <form action="/api/locations/{{ loc.id }}/delete" method="post" class="inline"
+                          data-confirm="Delete location '{{ loc.name }}'?">
+                        <button type="submit" class="text-shelf-muted hover:text-shelf-error text-sm transition-colors">
+                            Remove
+                        </button>
+                    </form>
+                </div>
+                <details>
+                    <summary class="text-shelf-muted text-sm">Edit</summary>
+                    <form action="/api/locations/{{ loc.id }}/update" method="post" class="space-y-2">
+                        <div>
+                            <label for="location-name-{{ loc.id }}" class="block text-sm font-medium text-shelf-muted mb-2">Name</label>
+                            <input id="location-name-{{ loc.id }}" type="text" name="name" value="{{ loc.label or loc.name }}" required
+                                   class="w-full bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-sm text-shelf-text focus:ring-2 focus:ring-shelf-accent outline-none">
+                        </div>
+                        <div>
+                            <label for="location-parent-{{ loc.id }}" class="block text-sm font-medium text-shelf-muted mb-2">Inside</label>
+                            <select id="location-parent-{{ loc.id }}" name="parent_id"
+                                    class="w-full bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-sm text-shelf-text focus:ring-2 focus:ring-shelf-accent outline-none">
+                                <option value="">Top level</option>
+                                {% for parent in locations %}
+                                {% if parent.id != loc.id %}
+                                <option value="{{ parent.id }}" {% if loc.parent_id == parent.id %}selected{% endif %}>{{ parent.name }}</option>
+                                {% endif %}
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <button type="submit" class="px-4 py-2 bg-shelf-accent text-white rounded-lg text-sm hover:bg-shelf-accent2 transition-colors">
+                            Save location
+                        </button>
+                    </form>
+                </details>
             </div>
             {% endfor %}
         </div>
         {% endif %}
 
-        <form action="/api/locations" method="post" class="flex gap-2">
+        <form action="/api/locations" method="post" class="space-y-2">
             <input type="text" name="name" placeholder="New location name..." required
-                   class="flex-1 min-w-0 bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-sm text-shelf-text focus:ring-2 focus:ring-shelf-accent outline-none">
+                   class="w-full bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-sm text-shelf-text focus:ring-2 focus:ring-shelf-accent outline-none">
+            <select name="parent_id"
+                    class="w-full bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-sm text-shelf-text focus:ring-2 focus:ring-shelf-accent outline-none">
+                <option value="">Top level</option>
+                {% for loc in locations %}
+                <option value="{{ loc.id }}">Inside {{ loc.name }}</option>
+                {% endfor %}
+            </select>
             <button type="submit" class="px-4 py-2 bg-shelf-accent text-white rounded-lg text-sm hover:bg-shelf-accent2 transition-colors">
                 Add
             </button>

--- a/docs/item-copies.md
+++ b/docs/item-copies.md
@@ -1,0 +1,30 @@
+# Physical copies
+
+Shelf distinguishes the shared catalogue description from individual physical
+objects through `item_copies`.
+
+A catalogue item may have zero, one, or many copy rows. Copy-specific fields
+include condition, acquisition details, provenance, notes, a local/accession
+barcode, and physical location. Digital or service-backed availability is not
+represented by an `item_copies` row merely because of its media type.
+
+## Compatibility with `items.location_id`
+
+The existing item-level location remains the compatibility field while the UI
+is migrated incrementally. When an item write supplies a non-null
+`location_id`, Shelf creates or updates one `is_primary = 1` copy. Clearing the
+item location clears that primary copy's location but does not delete the
+copy. Secondary copies are never moved by the legacy item field.
+
+The upgrade backfill is deliberately conservative: only an item that is both
+owned and already has an explicit legacy location receives a primary copy.
+`owned` alone is not treated as proof that the item is physical.
+
+The partial unique index on `item_copies(item_id)` permits at most one primary
+copy, `(item_id, copy_number)` is unique, and `copy_barcode` is unique across
+the collection. Deleting an item cascades to its copies; deleting a location
+sets copy locations to `NULL`.
+
+Hierarchical locations are intentionally a separate follow-up (upstream issue
+#98). The copy table references the existing `locations` row so that hierarchy
+can evolve without changing the catalogue/copy boundary.

--- a/docs/user-guide/locations.md
+++ b/docs/user-guide/locations.md
@@ -1,0 +1,34 @@
+# Locations
+
+Shelf can organise physical media in nested locations instead of forcing every place into one flat list.
+
+A location may be as broad or as specific as you need. For example:
+
+- `Living Room`
+- `Living Room / Bookcase`
+- `Living Room / Bookcase / Shelf 1`
+- `Bedroom / Shelf 1`
+
+The same label can therefore appear beneath different parents: `Shelf 1` in the living room is a different place from `Shelf 1` in the bedroom.
+
+## Create a nested location
+
+Open **Settings → Library → Locations**. Enter the new location label and, if it belongs inside another location, choose a parent. Leave the parent blank to create a top-level location.
+
+There is no fixed room/bookcase/shelf structure. Any level can be omitted and nesting can be as deep as your collection needs.
+
+## Move or rename a location
+
+Existing locations can be renamed or moved beneath another parent from the same Settings card. Shelf rewrites the displayed full path for that location and all of its descendants in one transaction, so existing item assignments continue to point at the same location records.
+
+Shelf prevents moving a location beneath itself or one of its descendants.
+
+## Delete a location
+
+A location that still contains child locations cannot be deleted. Move or delete the children first.
+
+Deleting a leaf location clears that location from items that used it. When the physical-copy model is present, the copy itself is retained and only its location is cleared.
+
+## Compatibility
+
+Shelf continues to keep an unambiguous full path in the existing `locations.name` field. This lets older catalogue, browse and export code display `Living Room / Shelf 1` without needing to understand the hierarchy immediately, while the new `label` and `parent_id` fields hold the real tree structure.

--- a/tests/test_hierarchical_locations.py
+++ b/tests/test_hierarchical_locations.py
@@ -1,0 +1,157 @@
+import pytest
+
+from app.services import item_copies
+from app.services import locations as location_svc
+from app.services.item_write import insert_item
+
+
+def test_legacy_flat_location_insert_is_kept_as_a_root(db):
+    row = db.execute(
+        "INSERT INTO locations (name, sort_order) VALUES ('Living Room', 0) RETURNING id"
+    ).fetchone()
+    location_id = row["id"]
+
+    # Legacy/raw callers may still know only the old flat columns. The tree
+    # service treats a missing node label as the legacy name rather than
+    # requiring a trigger (Shelf's secure restore rejects trigger-bearing DBs).
+    location = db.execute(
+        "SELECT name, label, parent_id FROM locations WHERE id = ?", (location_id,)
+    ).fetchone()
+    assert tuple(location) == ("Living Room", None, None)
+    tree_row = next(row for row in location_svc.location_tree(db) if row["id"] == location_id)
+    assert tree_row["label"] == "Living Room"
+    assert tree_row["depth"] == 0
+
+
+def test_arbitrary_depth_builds_unambiguous_full_paths(db):
+    room = location_svc.create_location(db, "Living Room")
+    case = location_svc.create_location(db, "Bookcase 1", parent_id=room)
+    shelf = location_svc.create_location(db, "Shelf 3", parent_id=case)
+
+    rows = db.execute(
+        "SELECT id, name, label, parent_id FROM locations ORDER BY id"
+    ).fetchall()
+    assert [tuple(row) for row in rows] == [
+        (room, "Living Room", "Living Room", None),
+        (case, "Living Room / Bookcase 1", "Bookcase 1", room),
+        (shelf, "Living Room / Bookcase 1 / Shelf 3", "Shelf 3", case),
+    ]
+
+
+def test_same_child_label_is_allowed_under_different_parents(db):
+    living = location_svc.create_location(db, "Living Room")
+    bedroom = location_svc.create_location(db, "Bedroom")
+
+    first = location_svc.create_location(db, "Shelf 1", parent_id=living)
+    second = location_svc.create_location(db, "Shelf 1", parent_id=bedroom)
+
+    assert db.execute("SELECT name FROM locations WHERE id = ?", (first,)).fetchone()["name"] == (
+        "Living Room / Shelf 1"
+    )
+    assert db.execute("SELECT name FROM locations WHERE id = ?", (second,)).fetchone()["name"] == (
+        "Bedroom / Shelf 1"
+    )
+
+
+def test_duplicate_sibling_labels_are_case_insensitive(db):
+    living = location_svc.create_location(db, "Living Room")
+    location_svc.create_location(db, "Shelf 1", parent_id=living)
+
+    with pytest.raises(location_svc.DuplicateLocation):
+        location_svc.create_location(db, "sHeLf 1", parent_id=living)
+
+
+def test_duplicate_root_labels_are_case_insensitive(db):
+    location_svc.create_location(db, "Archive")
+
+    with pytest.raises(location_svc.DuplicateLocation):
+        location_svc.create_location(db, "archive")
+
+
+def test_hierarchy_uses_no_database_triggers(db):
+    """Shelf's secure restore rejects trigger-bearing databases."""
+    triggers = db.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'trigger' AND name LIKE 'trg_locations_%'"
+    ).fetchall()
+    assert triggers == []
+
+
+def test_renaming_parent_rewrites_descendant_full_paths(db):
+    room = location_svc.create_location(db, "Living Room")
+    case = location_svc.create_location(db, "Bookcase 1", parent_id=room)
+    shelf = location_svc.create_location(db, "Shelf 3", parent_id=case)
+
+    location_svc.update_location(db, room, "Lounge")
+
+    assert db.execute("SELECT name FROM locations WHERE id = ?", (room,)).fetchone()["name"] == "Lounge"
+    assert db.execute("SELECT name FROM locations WHERE id = ?", (case,)).fetchone()["name"] == (
+        "Lounge / Bookcase 1"
+    )
+    assert db.execute("SELECT name FROM locations WHERE id = ?", (shelf,)).fetchone()["name"] == (
+        "Lounge / Bookcase 1 / Shelf 3"
+    )
+
+
+def test_reparenting_subtree_rewrites_all_descendant_paths(db):
+    living = location_svc.create_location(db, "Living Room")
+    bedroom = location_svc.create_location(db, "Bedroom")
+    case = location_svc.create_location(db, "Bookcase", parent_id=living)
+    shelf = location_svc.create_location(db, "Shelf 1", parent_id=case)
+
+    location_svc.update_location(db, case, "Bookcase", parent_id=bedroom)
+
+    assert db.execute("SELECT name FROM locations WHERE id = ?", (case,)).fetchone()["name"] == (
+        "Bedroom / Bookcase"
+    )
+    assert db.execute("SELECT name FROM locations WHERE id = ?", (shelf,)).fetchone()["name"] == (
+        "Bedroom / Bookcase / Shelf 1"
+    )
+
+
+def test_location_cannot_be_its_own_parent_or_move_under_descendant(db):
+    root = location_svc.create_location(db, "Room")
+    child = location_svc.create_location(db, "Case", parent_id=root)
+    grandchild = location_svc.create_location(db, "Shelf", parent_id=child)
+
+    with pytest.raises(location_svc.InvalidLocationParent):
+        location_svc.update_location(db, root, "Room", parent_id=root)
+    with pytest.raises(location_svc.InvalidLocationParent):
+        location_svc.update_location(db, root, "Room", parent_id=grandchild)
+
+
+def test_parent_with_children_must_be_emptied_before_delete(db):
+    root = location_svc.create_location(db, "Room")
+    location_svc.create_location(db, "Shelf", parent_id=root)
+
+    with pytest.raises(location_svc.LocationHasChildren):
+        location_svc.delete_location(db, root)
+
+
+def test_delete_leaf_clears_item_and_copy_location_without_deleting_copy(db):
+    shelf = location_svc.create_location(db, "Shelf")
+    item_id = insert_item(db, title="Placed", location_id=shelf)
+    copy_id = item_copies.copies_for_item(db, item_id)[0]["id"]
+
+    location_svc.delete_location(db, shelf)
+
+    item = db.execute("SELECT location_id FROM items WHERE id = ?", (item_id,)).fetchone()
+    copy = db.execute("SELECT id, location_id FROM item_copies WHERE id = ?", (copy_id,)).fetchone()
+    assert item["location_id"] is None
+    assert tuple(copy) == (copy_id, None)
+
+
+def test_tree_is_depth_first_and_sibling_sort_order_is_local(db):
+    living = location_svc.create_location(db, "Living", sort_order=20)
+    location_svc.create_location(db, "Bedroom", sort_order=10)
+    location_svc.create_location(db, "Shelf B", parent_id=living, sort_order=20)
+    shelf_a = location_svc.create_location(db, "Shelf A", parent_id=living, sort_order=10)
+    location_svc.create_location(db, "Box", parent_id=shelf_a)
+
+    tree = location_svc.location_tree(db)
+    assert [(row["name"], row["depth"]) for row in tree] == [
+        ("Bedroom", 0),
+        ("Living", 0),
+        ("Living / Shelf A", 1),
+        ("Living / Shelf A / Box", 2),
+        ("Living / Shelf B", 1),
+    ]

--- a/tests/test_item_copies.py
+++ b/tests/test_item_copies.py
@@ -1,0 +1,180 @@
+import sqlite3
+
+import pytest
+
+from app.services import item_copies
+from app.services.item_write import insert_item, update_item_fields, update_items_fields
+
+
+def _location(db, name="Living Room"):
+    return db.execute("INSERT INTO locations (name) VALUES (?)", (name,)).lastrowid
+
+
+def _item(db, title="Copy Test", *, owned=1, location_id=None, media_type="book"):
+    return db.execute(
+        "INSERT INTO items (title, media_type, source, owned, location_id) "
+        "VALUES (?, ?, 'test', ?, ?)",
+        (title, media_type, owned, location_id),
+    ).lastrowid
+
+
+def test_copy_model_allows_zero_one_or_many_rows_for_an_item(db):
+    living = _location(db)
+    item_id = _item(db)
+    assert item_copies.copies_for_item(db, item_id) == []
+
+    db.execute(
+        "INSERT INTO item_copies (item_id, copy_number, location_id, is_primary) "
+        "VALUES (?, 1, ?, 1)",
+        (item_id, living),
+    )
+    db.execute(
+        "INSERT INTO item_copies (item_id, copy_number, location_id, condition) "
+        "VALUES (?, 2, ?, 'good')",
+        (item_id, living),
+    )
+
+    copies = item_copies.copies_for_item(db, item_id)
+    assert [(r["copy_number"], r["location_id"]) for r in copies] == [
+        (1, living),
+        (2, living),
+    ]
+
+
+def test_primary_copy_is_unique_per_item(db):
+    item_id = _item(db)
+    db.execute(
+        "INSERT INTO item_copies (item_id, copy_number, is_primary) VALUES (?, 1, 1)",
+        (item_id,),
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        db.execute(
+            "INSERT INTO item_copies (item_id, copy_number, is_primary) VALUES (?, 2, 1)",
+            (item_id,),
+        )
+
+
+def test_copy_numbers_are_item_local_and_barcodes_are_global(db):
+    first = _item(db, "First")
+    second = _item(db, "Second")
+    db.execute(
+        "INSERT INTO item_copies (item_id, copy_number, copy_barcode, is_primary) "
+        "VALUES (?, 1, 'ASSET-42', 1)",
+        (first,),
+    )
+    db.execute(
+        "INSERT INTO item_copies (item_id, copy_number, is_primary) VALUES (?, 1, 1)",
+        (second,),
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        db.execute(
+            "INSERT INTO item_copies (item_id, copy_number) VALUES (?, 1)",
+            (first,),
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        db.execute(
+            "UPDATE item_copies SET copy_barcode = 'ASSET-42' WHERE item_id = ?",
+            (second,),
+        )
+
+
+def test_copy_metadata_is_independent_between_copies(db):
+    item_id = _item(db)
+    first = db.execute(
+        "INSERT INTO item_copies "
+        "(item_id, copy_number, condition, acquired_date, acquisition_source, "
+        "acquisition_price, provenance, notes, is_primary) "
+        "VALUES (?, 1, 'good', '2026-01-02', 'Bookshop', 12.50, "
+        "'Signed by author', 'Reading copy', 1)",
+        (item_id,),
+    ).lastrowid
+    second = db.execute(
+        "INSERT INTO item_copies "
+        "(item_id, copy_number, condition, acquisition_source, notes) "
+        "VALUES (?, 2, 'poor', 'Charity shop', 'Spare copy')",
+        (item_id,),
+    ).lastrowid
+
+    one = db.execute("SELECT * FROM item_copies WHERE id = ?", (first,)).fetchone()
+    two = db.execute("SELECT * FROM item_copies WHERE id = ?", (second,)).fetchone()
+    assert one["condition"] == "good"
+    assert one["acquisition_price"] == 12.5
+    assert one["provenance"] == "Signed by author"
+    assert two["condition"] == "poor"
+    assert two["acquisition_price"] is None
+
+
+def test_item_insert_with_location_creates_primary_copy(db):
+    living = _location(db)
+    item_id = insert_item(db, title="Placed", location_id=living)
+    copy = db.execute(
+        "SELECT * FROM item_copies WHERE item_id = ?", (item_id,)
+    ).fetchone()
+    assert copy["copy_number"] == 1
+    assert copy["location_id"] == living
+    assert copy["is_primary"] == 1
+
+
+def test_item_insert_without_location_does_not_guess_physical_copy(db):
+    item_id = insert_item(db, title="Unplaced", media_type="audiobook")
+    assert item_copies.copies_for_item(db, item_id) == []
+
+
+def test_single_item_location_updates_only_primary_copy(db):
+    living = _location(db)
+    bedroom = _location(db, "Bedroom")
+    item_id = insert_item(db, title="Placed", location_id=living)
+    db.execute(
+        "INSERT INTO item_copies (item_id, copy_number, location_id) VALUES (?, 2, ?)",
+        (item_id, living),
+    )
+
+    update_item_fields(db, item_id, {"location_id": bedroom})
+    rows = db.execute(
+        "SELECT copy_number, location_id FROM item_copies WHERE item_id = ? "
+        "ORDER BY copy_number",
+        (item_id,),
+    ).fetchall()
+    assert [tuple(r) for r in rows] == [(1, bedroom), (2, living)]
+
+
+def test_bulk_location_update_keeps_primary_compatibility(db):
+    living = _location(db)
+    first = insert_item(db, title="First")
+    second = insert_item(db, title="Second")
+
+    update_items_fields(db, [first, second], {"location_id": living})
+
+    rows = db.execute(
+        "SELECT item_id, location_id, is_primary FROM item_copies ORDER BY item_id"
+    ).fetchall()
+    assert [tuple(r) for r in rows] == [
+        (first, living, 1),
+        (second, living, 1),
+    ]
+
+
+def test_clearing_location_keeps_existing_copy_but_clears_its_place(db):
+    living = _location(db)
+    item_id = insert_item(db, title="Placed", location_id=living)
+
+    update_item_fields(db, item_id, {"location_id": None})
+
+    copy = db.execute(
+        "SELECT location_id FROM item_copies WHERE item_id = ? AND is_primary = 1",
+        (item_id,),
+    ).fetchone()
+    assert copy is not None
+    assert copy["location_id"] is None
+
+
+def test_owned_flag_is_independent_of_copy_rows(db):
+    living = _location(db)
+    item_id = insert_item(db, title="Placed", location_id=living)
+
+    update_item_fields(db, item_id, {"owned": 0})
+
+    assert db.execute(
+        "SELECT 1 FROM item_copies WHERE item_id = ?", (item_id,)
+    ).fetchone() is not None

--- a/tests/test_legacy_book.py
+++ b/tests/test_legacy_book.py
@@ -138,8 +138,14 @@ def test_resolver_does_not_swallow_cancellation():
 
 
 def test_mapping_table_exists_in_a_fresh_database_and_migration_24_is_append_only(db):
-    latest = max(version for version, _, _ in MIGRATIONS)
-    assert latest == 24
+    versions = [version for version, _, _ in MIGRATIONS]
+    assert versions == sorted(versions)
+    assert 24 in versions
+
+    version, description, sql = next(m for m in MIGRATIONS if m[0] == 24)
+    assert version == 24
+    assert description == "Add confirmed legacy book barcode mappings"
+    assert "CREATE TABLE IF NOT EXISTS legacy_book_mappings" in sql
 
     columns = {
         row[1] for row in db.execute("PRAGMA table_info(legacy_book_mappings)")

--- a/tests/test_location_hierarchy_routes.py
+++ b/tests/test_location_hierarchy_routes.py
@@ -1,0 +1,134 @@
+"""Route/UI regressions for hierarchical physical locations (#98)."""
+
+from app.services import locations as location_svc
+
+
+def test_create_location_under_parent_builds_full_path(admin_client, db):
+    parent = location_svc.create_location(db, "Living Room")
+    db.commit()
+
+    response = admin_client.post(
+        "/api/locations",
+        data={"name": "Shelf 1", "parent_id": str(parent)},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/settings"
+    row = db.execute(
+        "SELECT name, label, parent_id FROM locations WHERE label = 'Shelf 1'"
+    ).fetchone()
+    assert tuple(row) == ("Living Room / Shelf 1", "Shelf 1", parent)
+
+
+def test_same_child_name_can_exist_under_two_parents(admin_client, db):
+    living = location_svc.create_location(db, "Living Room")
+    bedroom = location_svc.create_location(db, "Bedroom")
+    db.commit()
+
+    for parent in (living, bedroom):
+        response = admin_client.post(
+            "/api/locations",
+            data={"name": "Shelf 1", "parent_id": str(parent)},
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+        assert response.headers["location"] == "/settings"
+
+    assert [
+        row["name"] for row in db.execute(
+            "SELECT name FROM locations WHERE label = 'Shelf 1' ORDER BY name"
+        ).fetchall()
+    ] == ["Bedroom / Shelf 1", "Living Room / Shelf 1"]
+
+
+def test_duplicate_child_name_under_same_parent_is_settings_error(admin_client, db):
+    parent = location_svc.create_location(db, "Living Room")
+    location_svc.create_location(db, "Shelf 1", parent_id=parent)
+    db.commit()
+
+    response = admin_client.post(
+        "/api/locations",
+        data={"name": "sHeLf 1", "parent_id": str(parent)},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/settings?location_error=duplicate"
+
+
+def test_reparent_route_rewrites_descendant_paths(admin_client, db):
+    living = location_svc.create_location(db, "Living Room")
+    bedroom = location_svc.create_location(db, "Bedroom")
+    case = location_svc.create_location(db, "Bookcase", parent_id=living)
+    shelf = location_svc.create_location(db, "Shelf 1", parent_id=case)
+    db.commit()
+
+    response = admin_client.post(
+        f"/api/locations/{case}/update",
+        data={"name": "Bookcase", "parent_id": str(bedroom)},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert db.execute("SELECT name FROM locations WHERE id = ?", (case,)).fetchone()["name"] == (
+        "Bedroom / Bookcase"
+    )
+    assert db.execute("SELECT name FROM locations WHERE id = ?", (shelf,)).fetchone()["name"] == (
+        "Bedroom / Bookcase / Shelf 1"
+    )
+
+
+def test_route_rejects_moving_parent_beneath_its_child(admin_client, db):
+    room = location_svc.create_location(db, "Room")
+    shelf = location_svc.create_location(db, "Shelf", parent_id=room)
+    db.commit()
+
+    response = admin_client.post(
+        f"/api/locations/{room}/update",
+        data={"name": "Room", "parent_id": str(shelf)},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/settings?location_error=invalid_parent"
+    row = db.execute("SELECT name, parent_id FROM locations WHERE id = ?", (room,)).fetchone()
+    assert tuple(row) == ("Room", None)
+
+
+def test_route_refuses_to_delete_parent_with_children(admin_client, db):
+    room = location_svc.create_location(db, "Room")
+    location_svc.create_location(db, "Shelf", parent_id=room)
+    db.commit()
+
+    response = admin_client.post(
+        f"/api/locations/{room}/delete",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/settings?location_error=has_children"
+    assert db.execute("SELECT 1 FROM locations WHERE id = ?", (room,)).fetchone()
+
+
+def test_settings_location_form_offers_parent_and_uses_node_label(admin_client, db):
+    room = location_svc.create_location(db, "Living Room")
+    shelf = location_svc.create_location(db, "Shelf 1", parent_id=room)
+    db.commit()
+
+    response = admin_client.get("/settings")
+
+    assert response.status_code == 200
+    assert 'name="parent_id"' in response.text
+    assert "Inside Living Room" in response.text
+    assert f'data-testid="location-row-{shelf}"' in response.text
+    assert 'value="Shelf 1"' in response.text
+    assert "Living Room / Shelf 1" in response.text
+
+
+def test_hierarchy_error_banner_uses_fixed_copy(admin_client):
+    response = admin_client.get("/settings?location_error=has_children")
+
+    assert response.status_code == 200
+    assert 'data-testid="location-tree-error-banner"' in response.text
+    assert "Move or remove this location's child locations before deleting it." in response.text


### PR DESCRIPTION
## What this changes

Adds a first-class physical-copy model beneath Shelf's existing catalogue items.

* An item remains the shared descriptive/catalogue record.
* `item_copies` represents individual physical objects.
* Each copy can hold its own condition, notes, acquisition date/source/price, provenance, location and local/accession barcode.
* Copy numbers are local to an item, while copy barcodes are globally unique.
* Items can have zero, one or many physical copies.
* Existing item-level location writes remain compatible by mirroring only the primary copy.
* Secondary copies are never silently moved by legacy item writes.
* Existing owned items are only backfilled when they already have an explicit physical location.
* No media type is guessed to be physical or digital from `owned` alone.

Fixes #97.

## Why

Shelf currently stores catalogue metadata and the ownership/location of a physical object on the same item row. That works for one copy, but cannot represent two copies of the same edition with different locations, condition, acquisition details or provenance.

Separating the catalogue item from its physical copies provides the foundation for duplicate copies, copy-specific lending, hierarchical locations, physical ordering and provenance without forcing digital or service-backed items into a physical-location model.

## Compatibility

The existing `items.location_id` field remains a compatibility projection during the transition. A primary copy mirrors that field; secondary copies remain independent.

The legacy backfill is deliberately conservative: only an owned item that already has an explicit location is treated as proven to have a physical copy. `owned=1` alone is not enough because digital and service-backed items may also be owned.

## Deliberately separate

This PR does not include copy-management UI, copy-specific lending, hierarchical locations (#98), physical shelf ordering, per-copy valuation, or digital/service holdings. Those can build on this foundation independently.

## Testing

The contribution branch has passed Shelf's full GitHub Actions validation, including unit/integration tests, offline lints, CSS reproducibility and the full browser E2E suite.
