### PR TITLE
Add Manga as a first-class media type

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -13,13 +13,14 @@ MEDIA_TYPES = {
     "dvd": "DVD / Blu-ray",
     "cd": "CD",
     "comic": "Comic / Graphic Novel",
+    "manga": "Manga",
     "video_game": "Video Game",
 }
 
 # The book family: media types that are read, carry ISBNs, and belong to a
 # series. Everything else in MEDIA_TYPES (dvd, cd, video_game) is a disc or a
 # cartridge. Declared here, beside the types themselves.
-BOOK_MEDIA_TYPES = frozenset({"book", "kids_book", "audiobook", "ebook", "comic"})
+BOOK_MEDIA_TYPES = frozenset({"book", "kids_book", "audiobook", "ebook", "comic", "manga"})
 
 # Seed data — runtime platform list comes from game_platforms table
 GAME_PLATFORMS = {

--- a/app/routers/items_catalog.py
+++ b/app/routers/items_catalog.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, Depends, Form, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 
 from app.auth import require_role
-from app.config import HTTP_TIMEOUT, MEDIA_TYPES
+from app.config import BOOK_MEDIA_TYPES, HTTP_TIMEOUT, MEDIA_TYPES
 from app.database import get_db, get_game_platforms, get_setting
 from app.routers import items_common
 from app.services import covers, igdb, openlibrary, scan_outcome, tmdb
@@ -181,8 +181,6 @@ async def add_game_from_search(
     )
     resp.headers["HX-Trigger"] = items_common._toast_header(f"Added: {metadata['title'][:50]}")
     return resp
-
-BOOK_MEDIA_TYPES = {"book", "kids_book", "audiobook", "ebook", "comic"}
 
 @router.get("/title-search")
 async def title_search(

--- a/app/routers/series.py
+++ b/app/routers/series.py
@@ -9,6 +9,7 @@ import logging
 from fastapi import APIRouter, Depends, Form, Request
 
 from app.auth import require_role
+from app.config import BOOK_MEDIA_TYPES
 from app.database import gc_orphaned_series_meta, get_db, get_setting
 from app.services import hardcover
 
@@ -21,10 +22,9 @@ router = APIRouter()
 # introducing a second, different limit for the same field.
 MAX_SERIES_NAME = 1000
 
-# Media types that can belong to a series. Deliberately a local literal,
-# not an import of items.BOOK_MEDIA_TYPES / synopsis.BOOK_MEDIA_TYPES (which
-# already disagree about comics) — see docs: issue #31 design plan §1.
-UNASSIGNED_MEDIA_TYPES = ("book", "kids_book", "audiobook", "ebook", "comic")
+# Media types that can belong to a series. Keep this derived from the canonical
+# config declaration so new book-family types cannot silently disappear here.
+UNASSIGNED_MEDIA_TYPES = tuple(sorted(BOOK_MEDIA_TYPES))
 # Covers shown in the Unassigned strip; the heading always shows the true total.
 UNASSIGNED_STRIP_CAP = 12
 

--- a/app/services/cover_queue.py
+++ b/app/services/cover_queue.py
@@ -164,7 +164,7 @@ async def _next_ready_job(queue: asyncio.Queue) -> Job:
     precisely during an outage, when fresh scans are still arriving.
 
     Rotating alone would busy-spin once *every* queued job is deferred, so
-after a full pass with nothing ready we sleep to the earliest deadline.
+    after a full pass with nothing ready we sleep to the earliest deadline.
     """
     checked = 0
     total = None

--- a/app/services/cover_queue.py
+++ b/app/services/cover_queue.py
@@ -43,8 +43,9 @@ REQUEUE_WINDOW_HOURS = 48
 # when the item has no authors (`authors.matches(None, …)` is True by
 # design) and then stores the ISBN it found. Sweeping a cover-less DVD or
 # video game through it writes a novel's cover and a book ISBN onto the
-# disc — silently, on every boot. Non-book cover misses stay manual.
-COVER_REQUEUE_MEDIA_TYPES = BOOK_MEDIA_TYPES + ("comic",)
+# disc — silently, on every boot. Comics and Manga share the same safe
+# book-catalogue cover path; non-book cover misses stay manual.
+COVER_REQUEUE_MEDIA_TYPES = BOOK_MEDIA_TYPES + ("comic", "manga")
 
 
 @dataclass
@@ -163,7 +164,7 @@ async def _next_ready_job(queue: asyncio.Queue) -> Job:
     precisely during an outage, when fresh scans are still arriving.
 
     Rotating alone would busy-spin once *every* queued job is deferred, so
-    after a full pass with nothing ready we sleep to the earliest deadline.
+after a full pass with nothing ready we sleep to the earliest deadline.
     """
     checked = 0
     total = None

--- a/app/services/detect.py
+++ b/app/services/detect.py
@@ -62,7 +62,7 @@ import re
 from dataclasses import dataclass
 from typing import Literal
 
-from app.config import MEDIA_TYPES
+from app.config import BOOK_MEDIA_TYPES, MEDIA_TYPES
 
 # How detection reached its verdict. Callers branch on what the answer is
 # *worth*, never on which tier produced it — a tier number is a fact about
@@ -91,10 +91,9 @@ class Detection:
 
 
 # Hints that mean "this is some kind of book" and are honoured as-is when the
-# barcode is an ISBN. Not every MEDIA_TYPES key is book-family — dvd, cd and
-# video_game are physical/digital media, not books, even though they are
-# valid hints on a non-ISBN scan.
-_BOOK_FAMILY_HINTS = frozenset({"book", "kids_book", "audiobook", "ebook", "comic"})
+# barcode is an ISBN. Keep this as the canonical config declaration so adding
+# a book-family media type cannot silently drift scan detection.
+_BOOK_FAMILY_HINTS = BOOK_MEDIA_TYPES
 
 # --- Tier 2: title markers -------------------------------------------------
 #
@@ -407,9 +406,8 @@ def detect_media_type(
     # G57: the question this branch exists to answer is "which MEDIA_TYPES
     # values can detection never produce?", and every one of them must survive
     # a no-signal outcome. Re-asked after the CD arms landed, the answer is
-    # now the book family only — `book`, `kids_book`, `audiobook`, `ebook`,
-    # `comic` — which is exactly `_BOOK_FAMILY_HINTS`, and those are wrong on
-    # a non-ISBN barcode for a different reason (tier 1's).
+    # now the book family, which is exactly `_BOOK_FAMILY_HINTS`, and those
+    # are wrong on a non-ISBN barcode for a different reason (tier 1's).
     if hint is not None and hint not in _BOOK_FAMILY_HINTS:
         return Detection(hint, (
             f"Nothing in the barcode or the product record said otherwise — "

--- a/app/templates/item_edit.html
+++ b/app/templates/item_edit.html
@@ -52,8 +52,8 @@
     <nav aria-label="Edit sections" data-testid="edit-section-nav" class="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-6">
         <a href="#edit-general" class="px-3 py-2 bg-shelf-card border border-shelf-border rounded-lg text-sm text-shelf-muted hover:text-shelf-text hover:border-shelf-accent/50 transition-colors">General</a>
         <a href="#edit-artwork" class="px-3 py-2 bg-shelf-card border border-shelf-border rounded-lg text-sm text-shelf-muted hover:text-shelf-text hover:border-shelf-accent/50 transition-colors">Artwork</a>
-        <a href="#edit-series" data-section-nav="series" data-media-types="book kids_book audiobook ebook comic" data-always-visible="{{ 'true' if item.series_name or item.series_position is not none or item.page_count is not none else 'false' }}" class="px-3 py-2 bg-shelf-card border border-shelf-border rounded-lg text-sm text-shelf-muted hover:text-shelf-text hover:border-shelf-accent/50 transition-colors">Series</a>
-        <a href="#edit-identifiers" data-section-nav="identifiers" data-media-types="book kids_book audiobook ebook comic" data-always-visible="{{ 'true' if item.isbn else 'false' }}" class="px-3 py-2 bg-shelf-card border border-shelf-border rounded-lg text-sm text-shelf-muted hover:text-shelf-text hover:border-shelf-accent/50 transition-colors">Identifiers</a>
+        <a href="#edit-series" data-section-nav="series" data-media-types="book kids_book audiobook ebook comic manga" data-always-visible="{{ 'true' if item.series_name or item.series_position is not none or item.page_count is not none else 'false' }}" class="px-3 py-2 bg-shelf-card border border-shelf-border rounded-lg text-sm text-shelf-muted hover:text-shelf-text hover:border-shelf-accent/50 transition-colors">Series</a>
+        <a href="#edit-identifiers" data-section-nav="identifiers" data-media-types="book kids_book audiobook ebook comic manga" data-always-visible="{{ 'true' if item.isbn else 'false' }}" class="px-3 py-2 bg-shelf-card border border-shelf-border rounded-lg text-sm text-shelf-muted hover:text-shelf-text hover:border-shelf-accent/50 transition-colors">Identifiers</a>
         <a href="#edit-location" class="px-3 py-2 bg-shelf-card border border-shelf-border rounded-lg text-sm text-shelf-muted hover:text-shelf-text hover:border-shelf-accent/50 transition-colors">Location</a>
         <a href="#edit-media" data-section-nav="media" data-media-types="video_game audiobook" data-always-visible="{{ 'true' if item.platform or item.narrator or item.duration_mins is not none else 'false' }}" class="px-3 py-2 bg-shelf-card border border-shelf-border rounded-lg text-sm text-shelf-muted hover:text-shelf-text hover:border-shelf-accent/50 transition-colors">Media Details</a>
     </nav>
@@ -94,7 +94,7 @@
                 {{ field("publish_year", "Year", item.publish_year, type="number") }}
             </div>
 
-            <div data-media-types="book kids_book audiobook ebook comic" data-always-visible="{{ 'true' if item.language else 'false' }}">
+            <div data-media-types="book kids_book audiobook ebook comic manga" data-always-visible="{{ 'true' if item.language else 'false' }}">
                 <label for="language" class="block text-sm font-medium text-shelf-muted mb-1">Language</label>
                 <select id="language" name="language"
                         class="w-full bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-shelf-text focus:ring-2 focus:ring-shelf-accent outline-none">
@@ -108,7 +108,7 @@
                 </select>
             </div>
 
-            <div data-media-types="book kids_book audiobook ebook comic" data-always-visible="{{ 'true' if item.reading_status or item.date_started or item.date_finished else 'false' }}" class="space-y-4">
+            <div data-media-types="book kids_book audiobook ebook comic manga" data-always-visible="{{ 'true' if item.reading_status or item.date_started or item.date_finished else 'false' }}" class="space-y-4">
                 <div>
                     <label for="reading_status" class="block text-sm font-medium text-shelf-muted mb-1">Reading Status</label>
                     <select id="reading_status" name="reading_status"
@@ -168,7 +168,7 @@
             </div>
         </section>
 
-        <section id="edit-series" data-testid="edit-section-series" data-media-types="book kids_book audiobook ebook comic" data-always-visible="{{ 'true' if item.series_name or item.series_position is not none or item.page_count is not none else 'false' }}" class="bg-shelf-card rounded-xl border border-shelf-border p-6 space-y-4">
+        <section id="edit-series" data-testid="edit-section-series" data-media-types="book kids_book audiobook ebook comic manga" data-always-visible="{{ 'true' if item.series_name or item.series_position is not none or item.page_count is not none else 'false' }}" class="bg-shelf-card rounded-xl border border-shelf-border p-6 space-y-4">
             <div>
                 <h2 class="text-lg font-semibold">Series</h2>
                 <p class="text-sm text-shelf-muted mt-1">Series membership, position and page count.</p>
@@ -180,7 +180,7 @@
             </div>
         </section>
 
-        <section id="edit-identifiers" data-testid="edit-section-identifiers" data-media-types="book kids_book audiobook ebook comic" data-always-visible="{{ 'true' if item.isbn else 'false' }}" class="bg-shelf-card rounded-xl border border-shelf-border p-6 space-y-4" x-data="isbnCamera">
+        <section id="edit-identifiers" data-testid="edit-section-identifiers" data-media-types="book kids_book audiobook ebook comic manga" data-always-visible="{{ 'true' if item.isbn else 'false' }}" class="bg-shelf-card rounded-xl border border-shelf-border p-6 space-y-4" x-data="isbnCamera">
             <div>
                 <h2 class="text-lg font-semibold">Identifiers</h2>
                 <p class="text-sm text-shelf-muted mt-1">Identifiers printed on this edition.</p>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,7 @@ the account menu — not from Settings.
   SBN or for DNB.
 - Outbound API pacing per host is fixed to each provider's published limit.
 - Media types are a fixed list: book, kids book, audiobook, eBook, DVD /
-  Blu-ray, CD, comic / graphic novel, video game. The scan tab's **Auto** is a
-  choice about how to scan, not a ninth type — it is never stored on an item;
-  see [Scanning → Media types](user-guide/scanning.md#media-types).
+  Blu-ray, CD, comic / graphic novel, Manga, video game. The scan tab's
+  **Auto** is a choice about how to scan, not a stored media type — it is
+  never stored on an item; see
+  [Scanning → Media types](user-guide/scanning.md#media-types).

--- a/docs/user-guide/browse-and-search.md
+++ b/docs/user-guide/browse-and-search.md
@@ -57,7 +57,7 @@ Filter chips along the top, all combinable:
 | Filter | Values |
 |---|---|
 | **Search** | Free text over title, author, ISBN, series, publisher |
-| **Type** | Book, kids book, audiobook, eBook, DVD / Blu-ray, CD, comic, video game |
+| **Type** | Book, kids book, audiobook, eBook, DVD / Blu-ray, CD, comic, Manga, video game |
 | **Location** | Any location, or "no location" |
 | **Reading status** | Want to read, reading, read, none |
 | **Owned** | Owned / wishlist |

--- a/docs/user-guide/scanning.md
+++ b/docs/user-guide/scanning.md
@@ -148,8 +148,8 @@ names music CDs, but when the record names **neither**, the dropdown is what
 says it — and the choice stands.
 
 Books further divide into book, kids book, audiobook, eBook, comic / graphic
-novel — the barcode cannot tell those apart, so they stay yours to pick.
-Change the type on the item page or in bulk from Browse.
+novel and Manga — the barcode cannot tell those apart, so they stay yours to
+pick. Change the type on the item page or in bulk from Browse.
 
 Whatever it decides, the card says so: *"Title names the Nintendo Switch
 platform — filed as Video Game."* or *"ISBN barcodes are books — overriding

--- a/tests/test_item_edit_sections.py
+++ b/tests/test_item_edit_sections.py
@@ -38,7 +38,7 @@ def test_item_edit_is_sectioned_without_changing_the_save_contract():
 
     # Media-specific groups stay in the DOM so changing Media Type can reveal
     # them immediately without changing what the form submits.
-    assert 'data-media-types="book kids_book audiobook ebook comic"' in template
+    assert 'data-media-types="book kids_book audiobook ebook comic manga"' in template
     assert 'data-media-types="video_game audiobook"' in template
     assert "updateEditSectionVisibility" in script
     assert "mediaSelect.addEventListener('change'" in script

--- a/tests/test_manga_media_type.py
+++ b/tests/test_manga_media_type.py
@@ -1,0 +1,22 @@
+"""Regression coverage for the standalone Manga media-type decision (#102)."""
+
+from app.config import BOOK_MEDIA_TYPES, MEDIA_TYPES
+from app.routers import items_catalog, series
+from app.services import cover_queue, detect
+
+
+def test_manga_is_a_first_class_book_family_media_type():
+    assert MEDIA_TYPES["manga"] == "Manga"
+    assert "manga" in BOOK_MEDIA_TYPES
+    assert items_catalog.BOOK_MEDIA_TYPES is BOOK_MEDIA_TYPES
+    assert set(series.UNASSIGNED_MEDIA_TYPES) == BOOK_MEDIA_TYPES
+    assert detect._BOOK_FAMILY_HINTS == BOOK_MEDIA_TYPES
+    assert "manga" in cover_queue.COVER_REQUEUE_MEDIA_TYPES
+
+
+def test_isbn_scan_preserves_an_explicit_manga_choice():
+    result = detect.detect_media_type("isbn", "manga", None, None)
+
+    assert result.media_type == "manga"
+    assert result.signal == "detected"
+    assert "Manga" in result.reason

--- a/tests/test_manga_media_type.py
+++ b/tests/test_manga_media_type.py
@@ -2,7 +2,7 @@
 
 from app.config import BOOK_MEDIA_TYPES, MEDIA_TYPES
 from app.routers import items_catalog, series
-from app.services import cover_queue, detect
+from app.services import cover_queue, detect, synopsis
 
 
 def test_manga_is_a_first_class_book_family_media_type():
@@ -12,6 +12,11 @@ def test_manga_is_a_first_class_book_family_media_type():
     assert set(series.UNASSIGNED_MEDIA_TYPES) == BOOK_MEDIA_TYPES
     assert detect._BOOK_FAMILY_HINTS == BOOK_MEDIA_TYPES
     assert "manga" in cover_queue.COVER_REQUEUE_MEDIA_TYPES
+
+
+def test_manga_does_not_enable_generic_synopsis_backfill():
+    """Treat Manga like Comic for synopsis until provider coverage justifies it."""
+    assert "manga" not in synopsis.BOOK_MEDIA_TYPES
 
 
 def test_isbn_scan_preserves_an_explicit_manga_choice():


### PR DESCRIPTION
<!--
Thanks for contributing to Shelf! For anything bigger than a small fix,
please open an issue first so we can talk about the approach before you
invest time — see CONTRIBUTING.md.
-->

## What this changes

<!-- A sentence or two. If it fixes an open issue, add "Fixes #123". -->

## Why

<!-- What problem does this solve? For a bug, what was the user-visible
     symptom? Skip if the "what" already makes it obvious. -->

## How it was tested

<!-- Which of the checks below you ran, plus anything you exercised by hand
     (which browser, which device, which scanner). -->

- [ ] `make test` passes
- [ ] `make test-e2e` passes
- [ ] `make checks` passes
- [ ] `make css` re-run, if templates or Tailwind classes changed

## Notes for review

<!-- Anything you're unsure about, deliberately left out, or want a second
     opinion on. Screenshots or a short clip help a lot for UI changes. -->

---

A few project-specific things that are easy to trip over — see `GOTCHAS.md`:

- Unit and E2E tests **cannot** share a pytest invocation; use the Make targets.
- Raw `fetch()` calls must send the `X-CSRF-Token` header (`make check-csrf`).
- Templates must stay compatible with the Alpine.js **CSP build**
  (`make check-alpine`) — nested or bracketed `x-model` bindings silently
  drop input.
- `MIGRATIONS` in `app/database.py` is append-only. Never edit or reorder an
  existing entry; add a new one at the end.
- No CDN references — all JS and CSS is vendored in `static/`.
