### PR TITLE
Add first-class Music catalogue on Shelf 0.36.0

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -106,20 +106,56 @@ MAX_TILES_PER_REQUEST = 16
 # Image input tokens ~= (w * h) / 750, capped per image at the model max.
 IMAGE_TOKEN_DIVISOR = 750
 ANTHROPIC_HIGHRES_IMAGE_TOKEN_CAP = 4784
+ANTHROPIC_STANDARD_IMAGE_TOKEN_CAP = 1600
 
-# --- External API rate limits ---------------------------------------------
-# Minimum seconds between requests to the same host. Used by
-# app/services/outbound.py. Values are deliberately a hair conservative.
-HOST_RATE_LIMITS = {
-    "openlibrary.org": 0.11,
-    "covers.openlibrary.org": 0.11,
-    "www.googleapis.com": 0.11,
-    "api2.isbndb.com": 1.05,
-    "hardcover.app": 0.12,
-    "api.hardcover.app": 0.12,
-    "images-na.ssl-images-amazon.com": 0.5,
-    "api.igdb.com": 0.25,
-    "api.themoviedb.org": 0.1,
+# USD per million tokens (input, output), matched by substring on model id.
+# Output dominates cost and scales with book count, not tile count.
+VISION_PRICING = {
+    "fable-5": (10.00, 50.00),
+    "opus": (5.00, 25.00),
+    "sonnet": (3.00, 15.00),
+    "haiku": (1.00, 5.00),
+}
+VISION_PRICING_DEFAULT = (5.00, 25.00)
+PROMPT_OVERHEAD_TOKENS = 500  # unified spine+cover prompt + JSON schema scaffolding
+TOKENS_PER_BOOK = 60  # ~1 JSON row, e.g. {"title": "Dune", "authors": "Frank Herbert", "isbn": "9780441172719", "source": "read"}
+EXPECTED_BOOKS_PER_MEGAPIXEL = 8  # rough spine density for output estimate
+EXPECTED_BOOKS_MIN = 20
+EXPECTED_BOOKS_MAX = 200
+
+# Minimum seconds between requests to a given outbound host, enforced by
+# app.services.outbound.acquire(). A host that is absent means "no pacing"
+# (interval 0.0) — that is the correct entry for LAN/self-hosted targets and
+# for hosts that publish no limit, not an oversight.
+#
+# Read this table as `app.config.HOST_RATE_LIMITS` at call time. A
+# `from app.config import HOST_RATE_LIMITS` freezes the reference at import
+# and breaks test overrides (the "Config import trap" in CLAUDE.md); tests
+# override single hosts with monkeypatch.setitem.
+HOST_RATE_LIMITS: dict[str, float] = {
+    # Open Library grants 1 req/s by default and 3 req/s to requests that
+    # identify themselves with an app name AND contact information
+    # (https://openlibrary.org/developers/api). openlibrary.py sends a
+    # contact URL in its User-Agent, so 3/s applies. If that header ever
+    # loses its contact info, this must drop to 1.0.
+    "openlibrary.org": 0.34,
+    # Two services behind one host: CoverID/OLID-keyed URLs are unlimited,
+    # every other key (ISBN, LCCN, OCLC) is capped at 100 requests per IP
+    # per 5 minutes and returns 403 past it
+    # (https://openlibrary.org/dev/docs/api/covers). 403 is not transient,
+    # so exceeding this reads as "no cover found" and fails silently — a
+    # per-host interval cannot tell the two key types apart, so pace for the
+    # limited one. Do not lower below 3.0.
+    "covers.openlibrary.org": 3.0,
+    "services.dnb.de": 1.0,  # DNB SRU catalog — good citizenship
+    "portal.dnb.de": 1.0,  # DNB cover host, same citizenship
+    "opac.sbn.it": 1.0,  # SBN publishes no rate limit; matches DNB, a comparable national library
+    "api.hardcover.app": 1.0,  # 60/min API limit
+    "api2.isbndb.com": 3.0,  # was isbndb's own 3s post-request sleep
+    "www.googleapis.com": 0.25,  # Google Books quota is per-day; light pacing only
+    "images-na.ssl-images-amazon.com": 0.5,  # image CDN; politeness only
+    "api.igdb.com": 0.25,  # IGDB publishes 4 req/s
+    "api.themoviedb.org": 0.1,  # no hard per-second cap
     # MusicBrainz asks ordinary clients to stay at or below one request per
     # second. Give the limiter a little margin instead of sitting exactly on
     # the boundary; musicbrainz.py also sends an identifying User-Agent.
@@ -130,45 +166,69 @@ HOST_RATE_LIMITS = {
     # EXPLORER (the keyless trial tier this client uses) allows 6 lookups per
     # minute and 100 per day; faster than the burst rate is declined with 429
     # (https://www.upcitemdb.com/wp/docs/main/development/api-rate-limits/).
-    "api.upcitemdb.com": 10.05,
-    "isbnsearch.org": 1.0,
-    "portal.issn.org": 1.05,
+    # 1.0 permitted 60/min — ten times the ceiling — so a run of scans bought
+    # 429s that read to the user as "not found". Do not lower below 10.0
+    # without moving off the trial tier.
+    "api.upcitemdb.com": 10.0,
 }
 
-HTTP_TIMEOUT = 15.0
+# HTTP client defaults
+HTTP_TIMEOUT = 15  # seconds for external API calls
 DEFAULT_PAGE_SIZE = 60
 
-# Environment-backed configuration is intentionally kept below the catalogue
-# constants above so tests that import MEDIA_TYPES do not have to initialise
-# any runtime state.
+# Auth
+SECRET_KEY = os.environ.get("SECRET_KEY", "")  # auto-generated into DATA_DIR/signing.key if empty
+JWT_ALGORITHM = "HS256"
+JWT_EXPIRY_SECONDS = 7 * 24 * 3600  # 7 days
+
+# API secret env var overrides (take priority over DB settings when set)
+# Map: settings key -> env var name
 SECRET_ENV_VARS = {
+    "abs_url": "ABS_URL",
+    "abs_public_url": "ABS_PUBLIC_URL",
+    "abs_token": "ABS_TOKEN",
     "hardcover_token": "HARDCOVER_TOKEN",
     "google_books_api_key": "GOOGLE_BOOKS_API_KEY",
+    "isbndb_api_key": "ISBNDB_API_KEY",
+    "tmdb_api_key": "TMDB_API_KEY",
     "igdb_client_id": "IGDB_CLIENT_ID",
     "igdb_client_secret": "IGDB_CLIENT_SECRET",
-    "tmdb_api_key": "TMDB_API_KEY",
-    "isbndb_api_key": "ISBNDB_API_KEY",
-    "abs_token": "ABS_TOKEN",
 }
-
-
-def get_setting_value(key: str, stored_value: str | None) -> str | None:
-    env_name = SECRET_ENV_VARS.get(key)
-    if env_name and os.environ.get(env_name) is not None:
-        return os.environ.get(env_name)
-    return stored_value
-
-
-def is_env_override(key: str) -> bool:
-    env_name = SECRET_ENV_VARS.get(key)
-    return bool(env_name and os.environ.get(env_name) is not None)
 
 
 def get_client_ip(request) -> str:
-    """Return the client IP, respecting trusted reverse-proxy headers."""
-    trust_proxy = os.environ.get("SHELF_TRUST_PROXY", "").lower() in {"1", "true", "yes"}
-    if trust_proxy:
-        forwarded = request.headers.get("x-forwarded-for")
-        if forwarded:
-            return forwarded.split(",", 1)[0].strip()
+    """Extract the real client IP for rate limiting and auth logs.
+
+    Proxy headers (CF-Connecting-IP, X-Forwarded-For) are client-controlled and
+    trivially spoofable, so they are only honored when SHELF_TRUST_PROXY is set —
+    i.e. the operator has a reverse proxy in front that overwrites them. In the
+    default direct-connection deployment we use the socket peer address.
+    """
+    if os.environ.get("SHELF_TRUST_PROXY"):
+        # Cloudflare sets this to the actual visitor IP
+        cf_ip = request.headers.get("cf-connecting-ip")
+        if cf_ip:
+            return cf_ip.strip()
+
+        # Standard proxy header — first entry is the original client
+        xff = request.headers.get("x-forwarded-for")
+        if xff:
+            return xff.split(",")[0].strip()
+
     return request.client.host if request.client else "unknown"
+
+
+def get_setting_value(key: str, db_value: str | None = None) -> str:
+    """Get a setting value with env var override. Env var takes priority."""
+    env_name = SECRET_ENV_VARS.get(key)
+    if env_name:
+        env_val = os.environ.get(env_name, "")
+        if env_val:
+            return env_val
+    return db_value or ""
+
+
+def is_env_override(key: str) -> bool:
+    """Check if a setting is being overridden by an env var."""
+    env_name = SECRET_ENV_VARS.get(key)
+    return bool(env_name and os.environ.get(env_name))

--- a/app/config.py
+++ b/app/config.py
@@ -15,7 +15,6 @@ MEDIA_TYPES = {
     "cassette": "Cassette",
     "cd": "CD",
     "digital_music": "Digital Music",
-    "music_other": "Other Music Format",
     "comic": "Comic / Graphic Novel",
     "video_game": "Video Game",
 }
@@ -33,7 +32,6 @@ MUSIC_MEDIA_TYPES = frozenset({
     "cassette",
     "cd",
     "digital_music",
-    "music_other",
 })
 
 # Seed data — runtime platform list comes from game_platforms table
@@ -108,56 +106,20 @@ MAX_TILES_PER_REQUEST = 16
 # Image input tokens ~= (w * h) / 750, capped per image at the model max.
 IMAGE_TOKEN_DIVISOR = 750
 ANTHROPIC_HIGHRES_IMAGE_TOKEN_CAP = 4784
-ANTHROPIC_STANDARD_IMAGE_TOKEN_CAP = 1600
 
-# USD per million tokens (input, output), matched by substring on model id.
-# Output dominates cost and scales with book count, not tile count.
-VISION_PRICING = {
-    "fable-5": (10.00, 50.00),
-    "opus": (5.00, 25.00),
-    "sonnet": (3.00, 15.00),
-    "haiku": (1.00, 5.00),
-}
-VISION_PRICING_DEFAULT = (5.00, 25.00)
-PROMPT_OVERHEAD_TOKENS = 500  # unified spine+cover prompt + JSON schema scaffolding
-TOKENS_PER_BOOK = 60  # ~1 JSON row, e.g. {"title": "Dune", "authors": "Frank Herbert", "isbn": "9780441172719", "source": "read"}
-EXPECTED_BOOKS_PER_MEGAPIXEL = 8  # rough spine density for output estimate
-EXPECTED_BOOKS_MIN = 20
-EXPECTED_BOOKS_MAX = 200
-
-# Minimum seconds between requests to a given outbound host, enforced by
-# app.services.outbound.acquire(). A host that is absent means "no pacing"
-# (interval 0.0) — that is the correct entry for LAN/self-hosted targets and
-# for hosts that publish no limit, not an oversight.
-#
-# Read this table as `app.config.HOST_RATE_LIMITS` at call time. A
-# `from app.config import HOST_RATE_LIMITS` freezes the reference at import
-# and breaks test overrides (the "Config import trap" in CLAUDE.md); tests
-# override single hosts with monkeypatch.setitem.
-HOST_RATE_LIMITS: dict[str, float] = {
-    # Open Library grants 1 req/s by default and 3 req/s to requests that
-    # identify themselves with an app name AND contact information
-    # (https://openlibrary.org/developers/api). openlibrary.py sends a
-    # contact URL in its User-Agent, so 3/s applies. If that header ever
-    # loses its contact info, this must drop to 1.0.
-    "openlibrary.org": 0.34,
-    # Two services behind one host: CoverID/OLID-keyed URLs are unlimited,
-    # every other key (ISBN, LCCN, OCLC) is capped at 100 requests per IP
-    # per 5 minutes and returns 403 past it
-    # (https://openlibrary.org/dev/docs/api/covers). 403 is not transient,
-    # so exceeding this reads as "no cover found" and fails silently — a
-    # per-host interval cannot tell the two key types apart, so pace for the
-    # limited one. Do not lower below 3.0.
-    "covers.openlibrary.org": 3.0,
-    "services.dnb.de": 1.0,  # DNB SRU catalog — good citizenship
-    "portal.dnb.de": 1.0,  # DNB cover host, same citizenship
-    "opac.sbn.it": 1.0,  # SBN publishes no rate limit; matches DNB, a comparable national library
-    "api.hardcover.app": 1.0,  # 60/min API limit
-    "api2.isbndb.com": 3.0,  # was isbndb's own 3s post-request sleep
-    "www.googleapis.com": 0.25,  # Google Books quota is per-day; light pacing only
-    "images-na.ssl-images-amazon.com": 0.5,  # image CDN; politeness only
-    "api.igdb.com": 0.25,  # IGDB publishes 4 req/s
-    "api.themoviedb.org": 0.1,  # no hard per-second cap
+# --- External API rate limits ---------------------------------------------
+# Minimum seconds between requests to the same host. Used by
+# app/services/outbound.py. Values are deliberately a hair conservative.
+HOST_RATE_LIMITS = {
+    "openlibrary.org": 0.11,
+    "covers.openlibrary.org": 0.11,
+    "www.googleapis.com": 0.11,
+    "api2.isbndb.com": 1.05,
+    "hardcover.app": 0.12,
+    "api.hardcover.app": 0.12,
+    "images-na.ssl-images-amazon.com": 0.5,
+    "api.igdb.com": 0.25,
+    "api.themoviedb.org": 0.1,
     # MusicBrainz asks ordinary clients to stay at or below one request per
     # second. Give the limiter a little margin instead of sitting exactly on
     # the boundary; musicbrainz.py also sends an identifying User-Agent.
@@ -168,69 +130,45 @@ HOST_RATE_LIMITS: dict[str, float] = {
     # EXPLORER (the keyless trial tier this client uses) allows 6 lookups per
     # minute and 100 per day; faster than the burst rate is declined with 429
     # (https://www.upcitemdb.com/wp/docs/main/development/api-rate-limits/).
-    # 1.0 permitted 60/min — ten times the ceiling — so a run of scans bought
-    # 429s that read to the user as "not found". Do not lower below 10.0
-    # without moving off the trial tier.
-    "api.upcitemdb.com": 10.0,
+    "api.upcitemdb.com": 10.05,
+    "isbnsearch.org": 1.0,
+    "portal.issn.org": 1.05,
 }
 
-# HTTP client defaults
-HTTP_TIMEOUT = 15  # seconds for external API calls
+HTTP_TIMEOUT = 15.0
 DEFAULT_PAGE_SIZE = 60
 
-# Auth
-SECRET_KEY = os.environ.get("SECRET_KEY", "")  # auto-generated into DATA_DIR/signing.key if empty
-JWT_ALGORITHM = "HS256"
-JWT_EXPIRY_SECONDS = 7 * 24 * 3600  # 7 days
-
-# API secret env var overrides (take priority over DB settings when set)
-# Map: settings key -> env var name
+# Environment-backed configuration is intentionally kept below the catalogue
+# constants above so tests that import MEDIA_TYPES do not have to initialise
+# any runtime state.
 SECRET_ENV_VARS = {
-    "abs_url": "ABS_URL",
-    "abs_public_url": "ABS_PUBLIC_URL",
-    "abs_token": "ABS_TOKEN",
     "hardcover_token": "HARDCOVER_TOKEN",
     "google_books_api_key": "GOOGLE_BOOKS_API_KEY",
-    "isbndb_api_key": "ISBNDB_API_KEY",
-    "tmdb_api_key": "TMDB_API_KEY",
     "igdb_client_id": "IGDB_CLIENT_ID",
     "igdb_client_secret": "IGDB_CLIENT_SECRET",
+    "tmdb_api_key": "TMDB_API_KEY",
+    "isbndb_api_key": "ISBNDB_API_KEY",
+    "abs_token": "ABS_TOKEN",
 }
 
 
-def get_client_ip(request) -> str:
-    """Extract the real client IP for rate limiting and auth logs.
-
-    Proxy headers (CF-Connecting-IP, X-Forwarded-For) are client-controlled and
-    trivially spoofable, so they are only honored when SHELF_TRUST_PROXY is set —
-    i.e. the operator has a reverse proxy in front that overwrites them. In the
-    default direct-connection deployment we use the socket peer address.
-    """
-    if os.environ.get("SHELF_TRUST_PROXY"):
-        # Cloudflare sets this to the actual visitor IP
-        cf_ip = request.headers.get("cf-connecting-ip")
-        if cf_ip:
-            return cf_ip.strip()
-
-        # Standard proxy header — first entry is the original client
-        xff = request.headers.get("x-forwarded-for")
-        if xff:
-            return xff.split(",")[0].strip()
-
-    return request.client.host if request.client else "unknown"
-
-
-def get_setting_value(key: str, db_value: str | None = None) -> str:
-    """Get a setting value with env var override. Env var takes priority."""
+def get_setting_value(key: str, stored_value: str | None) -> str | None:
     env_name = SECRET_ENV_VARS.get(key)
-    if env_name:
-        env_val = os.environ.get(env_name, "")
-        if env_val:
-            return env_val
-    return db_value or ""
+    if env_name and os.environ.get(env_name) is not None:
+        return os.environ.get(env_name)
+    return stored_value
 
 
 def is_env_override(key: str) -> bool:
-    """Check if a setting is being overridden by an env var."""
     env_name = SECRET_ENV_VARS.get(key)
-    return bool(env_name and os.environ.get(env_name))
+    return bool(env_name and os.environ.get(env_name) is not None)
+
+
+def get_client_ip(request) -> str:
+    """Return the client IP, respecting trusted reverse-proxy headers."""
+    trust_proxy = os.environ.get("SHELF_TRUST_PROXY", "").lower() in {"1", "true", "yes"}
+    if trust_proxy:
+        forwarded = request.headers.get("x-forwarded-for")
+        if forwarded:
+            return forwarded.split(",", 1)[0].strip()
+    return request.client.host if request.client else "unknown"

--- a/app/config.py
+++ b/app/config.py
@@ -11,15 +11,30 @@ MEDIA_TYPES = {
     "audiobook": "Audiobook",
     "ebook": "eBook",
     "dvd": "DVD / Blu-ray",
+    "vinyl": "Vinyl",
+    "cassette": "Cassette",
     "cd": "CD",
+    "digital_music": "Digital Music",
+    "music_other": "Other Music Format",
     "comic": "Comic / Graphic Novel",
     "video_game": "Video Game",
 }
 
 # The book family: media types that are read, carry ISBNs, and belong to a
-# series. Everything else in MEDIA_TYPES (dvd, cd, video_game) is a disc or a
-# cartridge. Declared here, beside the types themselves.
+# series. Everything else is deliberately outside this family.
 BOOK_MEDIA_TYPES = frozenset({"book", "kids_book", "audiobook", "ebook", "comic"})
+
+# Music is a first-class media family. Keep this declaration beside
+# MEDIA_TYPES so routes/templates/services can share one membership test.
+# `cd` is the existing upstream CD type; adding music does not create a
+# second incompatible CD identity.
+MUSIC_MEDIA_TYPES = frozenset({
+    "vinyl",
+    "cassette",
+    "cd",
+    "digital_music",
+    "music_other",
+})
 
 # Seed data — runtime platform list comes from game_platforms table
 GAME_PLATFORMS = {
@@ -143,6 +158,13 @@ HOST_RATE_LIMITS: dict[str, float] = {
     "images-na.ssl-images-amazon.com": 0.5,  # image CDN; politeness only
     "api.igdb.com": 0.25,  # IGDB publishes 4 req/s
     "api.themoviedb.org": 0.1,  # no hard per-second cap
+    # MusicBrainz asks ordinary clients to stay at or below one request per
+    # second. Give the limiter a little margin instead of sitting exactly on
+    # the boundary; musicbrainz.py also sends an identifying User-Agent.
+    "musicbrainz.org": 1.05,
+    # Cover Art Archive is separate from MusicBrainz. Artwork requests are
+    # not latency critical, so pace them conservatively too.
+    "coverartarchive.org": 1.0,
     # EXPLORER (the keyless trial tier this client uses) allows 6 lookups per
     # minute and 100 per day; faster than the burst rate is declined with 429
     # (https://www.upcitemdb.com/wp/docs/main/development/api-rate-limits/).

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,0 +1,8 @@
+"""Router package composition for the self-contained Music contribution."""
+
+from app.routers import music as _music
+from app.routers import pages as _pages
+from app.services import music_covers as _music_covers
+
+_music_covers.register_cover_art_archive()
+_pages.router.include_router(_music.router)

--- a/app/routers/music.py
+++ b/app/routers/music.py
@@ -1,0 +1,298 @@
+"""First-class music catalogue routes built around exact MusicBrainz releases."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import httpx
+from fastapi import APIRouter, Depends, Form, Query, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from app.auth import require_role
+from app.config import HTTP_TIMEOUT, MEDIA_TYPES, MUSIC_MEDIA_TYPES
+from app.database import get_db
+from app.services import covers, music_catalog, musicbrainz
+from app.services import upc as upc_svc
+from app.services.item_write import insert_item, update_item_fields
+from app.services.write_targets import UnknownLocationError, validated_location_id
+
+router = APIRouter()
+
+
+def _year(value: str | None) -> int | None:
+    text = (value or "").strip()
+    return int(text[:4]) if len(text) >= 4 and text[:4].isdigit() else None
+
+
+def _infer_media_type(release: dict) -> str:
+    """Map MusicBrainz medium formats onto Shelf's music media family."""
+    formats = [
+        str(m.get("format") or "").casefold()
+        for m in release.get("media") or []
+        if isinstance(m, dict)
+    ]
+    summary = str(release.get("format_summary") or "").casefold()
+    if not formats and summary:
+        formats = [summary]
+
+    for fmt in formats:
+        if "vinyl" in fmt or fmt in {'7"', '10"', '12"'}:
+            return "vinyl"
+        if "cassette" in fmt:
+            return "cassette"
+        if fmt == "cd" or "compact disc" in fmt:
+            return "cd"
+        if "digital" in fmt:
+            return "digital_music"
+    return "music_other"
+
+
+def _provider_error(result) -> str | None:
+    if result is None or result.found:
+        return None
+    return {
+        "rate_limited": "MusicBrainz is rate-limiting requests. Try again shortly.",
+        "transport_failed": "MusicBrainz could not be reached.",
+        "rejected": "MusicBrainz rejected the request.",
+        "no_match": "No matching releases were found.",
+    }.get(result.outcome, "MusicBrainz search failed.")
+
+
+def _music_types_sql() -> tuple[str, tuple[str, ...]]:
+    values = tuple(sorted(MUSIC_MEDIA_TYPES))
+    return ",".join("?" for _ in values), values
+
+
+async def _apply_release_artwork(item_id: int, release_id: str) -> None:
+    """Fill a missing cover from Cover Art Archive without overwriting one."""
+    with get_db() as db:
+        row = db.execute(
+            "SELECT cover_path FROM items WHERE id = ?", (item_id,)
+        ).fetchone()
+    if not row or row["cover_path"]:
+        return
+
+    async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+        art = await musicbrainz.cover_art(release_id, client)
+        candidates = art.payload if art.found else []
+        front = next((c for c in candidates if c.get("front")), None)
+        chosen = front or (candidates[0] if candidates else None)
+        if not chosen:
+            return
+        cover_path = await covers._download_to_item(item_id, chosen["url"], client)
+
+    if cover_path:
+        with get_db() as db:
+            update_item_fields(db, item_id, {"cover_path": cover_path})
+
+
+@router.get("/music")
+async def music_page(
+    request: Request,
+    q: str = Query(""),
+    artist: str = Query(""),
+    barcode: str = Query(""),
+    catalog_number: str = Query(""),
+    _=Depends(require_role("viewer")),
+):
+    """Browse catalogued music and search exact MusicBrainz releases."""
+    q = q.strip()[:200]
+    artist = artist.strip()[:200]
+    barcode = upc_svc.normalize_barcode(barcode)[:32]
+    catalog_number = catalog_number.strip()[:100]
+
+    placeholders, music_types = _music_types_sql()
+    with get_db() as db:
+        music_catalog.ensure_schema(db)
+        items = db.execute(
+            f"""SELECT i.id, i.title, i.authors, i.media_type, i.cover_path,
+                       i.publish_year, mr.format_summary, mr.catalog_number,
+                       mr.release_date
+                FROM items i
+                LEFT JOIN music_releases mr ON mr.item_id = i.id
+                WHERE i.media_type IN ({placeholders})
+                ORDER BY i.authors COLLATE NOCASE, i.title COLLATE NOCASE, i.id
+                LIMIT 250""",
+            music_types,
+        ).fetchall()
+        locations = db.execute(
+            "SELECT id, name FROM locations ORDER BY sort_order, name"
+        ).fetchall()
+
+    results: list[dict] = []
+    error = None
+    if q or artist or barcode or catalog_number:
+        async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+            result = await musicbrainz.search_releases(
+                q,
+                client,
+                artist=artist or None,
+                barcode=barcode or None,
+                catalog_number=catalog_number or None,
+                limit=20,
+            )
+        if result.found:
+            results = result.payload or []
+            for release in results:
+                media_type = _infer_media_type(release)
+                release["shelf_media_type"] = media_type
+                release["shelf_media_label"] = MEDIA_TYPES[media_type]
+        else:
+            error = _provider_error(result)
+
+    return request.app.state.templates.TemplateResponse(
+        request,
+        "music.html",
+        {
+            "items": items,
+            "results": results,
+            "error": error,
+            "q": q,
+            "artist": artist,
+            "barcode": barcode,
+            "catalog_number": catalog_number,
+            "locations": locations,
+            "music_media_types": {
+                key: MEDIA_TYPES[key]
+                for key in MEDIA_TYPES
+                if key in MUSIC_MEDIA_TYPES
+            },
+        },
+    )
+
+
+@router.post("/api/music/add")
+async def add_music_release(
+    release_id: str = Form(...),
+    media_type: str = Form(""),
+    location_id: int | None = Form(None),
+    owned: int = Form(1),
+    _=Depends(require_role("editor")),
+):
+    """Add one exact MusicBrainz release to Shelf."""
+    release_id = release_id.strip()
+    if not release_id:
+        return RedirectResponse("/music", status_code=303)
+
+    with get_db() as db:
+        music_catalog.ensure_schema(db)
+        existing = db.execute(
+            "SELECT item_id FROM music_releases WHERE musicbrainz_release_id = ?",
+            (release_id,),
+        ).fetchone()
+    if existing:
+        return RedirectResponse(f"/music/item/{existing['item_id']}", status_code=303)
+
+    async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+        result = await musicbrainz.lookup_release(release_id, client)
+    if not result.found:
+        return HTMLResponse(_provider_error(result) or "Release lookup failed", status_code=502)
+
+    release = result.payload
+    if media_type not in MUSIC_MEDIA_TYPES:
+        media_type = _infer_media_type(release)
+
+    provider_barcode = upc_svc.normalize_upc(release.get("barcode") or "") or None
+    publish_year = _year(release.get("release_date")) or _year(
+        release.get("first_release_date")
+    )
+
+    try:
+        with get_db() as db:
+            loc_id = validated_location_id(db, location_id)
+            item_id = insert_item(
+                db,
+                title=release["title"],
+                authors=release.get("artist_credit"),
+                upc=provider_barcode,
+                media_type=media_type,
+                publisher=release.get("label"),
+                publish_year=publish_year,
+                location_id=loc_id,
+                owned=1 if owned else 0,
+                source="musicbrainz",
+            )
+            music_catalog.save_release(db, item_id, release)
+    except UnknownLocationError:
+        return HTMLResponse("Selected location no longer exists", status_code=400)
+    except sqlite3.IntegrityError:
+        with get_db() as db:
+            existing = db.execute(
+                "SELECT item_id FROM music_releases WHERE musicbrainz_release_id = ?",
+                (release_id,),
+            ).fetchone()
+            if not existing and provider_barcode:
+                existing = db.execute(
+                    "SELECT id AS item_id FROM items WHERE upc = ? AND media_type = ?",
+                    (provider_barcode, media_type),
+                ).fetchone()
+        if existing:
+            return RedirectResponse(
+                f"/music/item/{existing['item_id']}", status_code=303
+            )
+        raise
+
+    await _apply_release_artwork(item_id, release_id)
+    return RedirectResponse(f"/music/item/{item_id}", status_code=303)
+
+
+@router.get("/music/item/{item_id}")
+async def music_item_page(
+    request: Request,
+    item_id: int,
+    _=Depends(require_role("viewer")),
+):
+    with get_db() as db:
+        item = db.execute(
+            "SELECT * FROM items WHERE id = ?", (item_id,)
+        ).fetchone()
+        if not item or item["media_type"] not in MUSIC_MEDIA_TYPES:
+            return RedirectResponse(f"/item/{item_id}", status_code=303)
+        release = music_catalog.get_release(db, item_id)
+
+    return request.app.state.templates.TemplateResponse(
+        request,
+        "music_item.html",
+        {"item": item, "release": release, "media_types": MEDIA_TYPES},
+    )
+
+
+@router.post("/api/music/items/{item_id}/refresh")
+async def refresh_music_release(
+    item_id: int,
+    _=Depends(require_role("editor")),
+):
+    with get_db() as db:
+        item = db.execute(
+            "SELECT * FROM items WHERE id = ?", (item_id,)
+        ).fetchone()
+        release = music_catalog.get_release(db, item_id) if item else None
+    if not item or item["media_type"] not in MUSIC_MEDIA_TYPES or not release:
+        return HTMLResponse("Music release not found", status_code=404)
+
+    release_id = release.get("musicbrainz_release_id")
+    if not release_id:
+        return HTMLResponse("MusicBrainz release ID is missing", status_code=400)
+
+    async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+        result = await musicbrainz.lookup_release(release_id, client)
+    if not result.found:
+        return HTMLResponse(_provider_error(result) or "Release lookup failed", status_code=502)
+
+    refreshed = result.payload
+    with get_db() as db:
+        update_item_fields(
+            db,
+            item_id,
+            {
+                "title": refreshed["title"],
+                "authors": refreshed.get("artist_credit"),
+                "publisher": refreshed.get("label"),
+                "publish_year": _year(refreshed.get("release_date"))
+                or _year(refreshed.get("first_release_date")),
+            },
+        )
+        music_catalog.save_release(db, item_id, refreshed)
+
+    await _apply_release_artwork(item_id, release_id)
+    return RedirectResponse(f"/music/item/{item_id}", status_code=303)

--- a/app/routers/music.py
+++ b/app/routers/music.py
@@ -24,8 +24,14 @@ def _year(value: str | None) -> int | None:
     return int(text[:4]) if len(text) >= 4 and text[:4].isdigit() else None
 
 
-def _infer_media_type(release: dict) -> str:
-    """Map MusicBrainz medium formats onto Shelf's music media family."""
+def _infer_media_type(release: dict) -> str | None:
+    """Map recognised MusicBrainz medium formats onto Shelf's music family.
+
+    Unknown formats deliberately stay unset so the add screen asks the user
+    instead of exposing a permanent catch-all media type or guessing CD.
+    Exact provider format strings are still retained in ``music_media`` and
+    ``music_releases.format_summary``.
+    """
     formats = [
         str(m.get("format") or "").casefold()
         for m in release.get("media") or []
@@ -44,7 +50,7 @@ def _infer_media_type(release: dict) -> str:
             return "cd"
         if "digital" in fmt:
             return "digital_music"
-    return "music_other"
+    return None
 
 
 def _provider_error(result) -> str | None:
@@ -136,7 +142,9 @@ async def music_page(
             for release in results:
                 media_type = _infer_media_type(release)
                 release["shelf_media_type"] = media_type
-                release["shelf_media_label"] = MEDIA_TYPES[media_type]
+                release["shelf_media_label"] = (
+                    MEDIA_TYPES[media_type] if media_type else "Choose format"
+                )
         else:
             error = _provider_error(result)
 
@@ -190,7 +198,9 @@ async def add_music_release(
 
     release = result.payload
     if media_type not in MUSIC_MEDIA_TYPES:
-        media_type = _infer_media_type(release)
+        media_type = _infer_media_type(release) or ""
+    if not media_type:
+        return HTMLResponse("Choose a music format before adding this release", status_code=400)
 
     provider_barcode = upc_svc.normalize_upc(release.get("barcode") or "") or None
     publish_year = _year(release.get("release_date")) or _year(

--- a/app/services/music_catalog.py
+++ b/app/services/music_catalog.py
@@ -1,0 +1,260 @@
+"""Persistence helpers for Shelf's music-specific relational model.
+
+The generic ``items`` row remains Shelf's catalogue object. These helpers
+store exact MusicBrainz release metadata beneath it and automatically link
+other catalogued formats that belong to the same MusicBrainz Release Group.
+
+Physical-copy condition, acquisition and provenance are intentionally not
+stored here; those belong to the copy model proposed separately in #97.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS music_releases (
+    item_id                       INTEGER PRIMARY KEY REFERENCES items(id) ON DELETE CASCADE,
+    artist_credit                 TEXT,
+    musicbrainz_release_id        TEXT UNIQUE,
+    musicbrainz_release_group_id  TEXT,
+    release_type                  TEXT,
+    release_status                TEXT,
+    release_date                  TEXT,
+    first_release_date            TEXT,
+    country                       TEXT,
+    label                         TEXT,
+    catalog_number                TEXT,
+    packaging                     TEXT,
+    media_count                   INTEGER,
+    format_summary                TEXT,
+    metadata_source               TEXT,
+    metadata_updated_at           TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_music_releases_artist
+    ON music_releases(artist_credit COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS idx_music_releases_group
+    ON music_releases(musicbrainz_release_group_id);
+CREATE INDEX IF NOT EXISTS idx_music_releases_catalog
+    ON music_releases(catalog_number COLLATE NOCASE);
+
+CREATE TABLE IF NOT EXISTS music_media (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    item_id     INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    position    INTEGER NOT NULL,
+    format      TEXT,
+    title       TEXT,
+    track_count INTEGER,
+    UNIQUE(item_id, position)
+);
+CREATE INDEX IF NOT EXISTS idx_music_media_item ON music_media(item_id);
+
+CREATE TABLE IF NOT EXISTS music_tracks (
+    id                         INTEGER PRIMARY KEY AUTOINCREMENT,
+    medium_id                  INTEGER NOT NULL REFERENCES music_media(id) ON DELETE CASCADE,
+    position                   INTEGER NOT NULL,
+    number                     TEXT,
+    title                      TEXT NOT NULL,
+    artist_credit              TEXT,
+    duration_ms                INTEGER,
+    musicbrainz_recording_id   TEXT,
+    UNIQUE(medium_id, position)
+);
+CREATE INDEX IF NOT EXISTS idx_music_tracks_medium ON music_tracks(medium_id);
+CREATE INDEX IF NOT EXISTS idx_music_tracks_recording ON music_tracks(musicbrainz_recording_id);
+
+CREATE TABLE IF NOT EXISTS music_identifiers (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    item_id          INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    identifier_type  TEXT NOT NULL,
+    value            TEXT NOT NULL,
+    description      TEXT,
+    UNIQUE(item_id, identifier_type, value)
+);
+CREATE INDEX IF NOT EXISTS idx_music_identifiers_item ON music_identifiers(item_id);
+CREATE INDEX IF NOT EXISTS idx_music_identifiers_value
+    ON music_identifiers(value COLLATE NOCASE);
+"""
+
+
+def ensure_schema(db) -> None:
+    """Install the music catalogue tables idempotently on the caller's DB.
+
+    This first upstream slice owns its schema locally so it can be validated
+    without consuming an upstream migration number before the maintainer has
+    agreed the final music model. A production integration can move these
+    statements into Shelf's normal bootstrap once the shape is accepted.
+    """
+    db.executescript(_SCHEMA)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def save_release(db, item_id: int, release: dict) -> None:
+    """Upsert release metadata and replace its provider-owned media/track tree."""
+    ensure_schema(db)
+    db.execute(
+        """
+        INSERT INTO music_releases (
+            item_id, artist_credit, musicbrainz_release_id,
+            musicbrainz_release_group_id, release_type, release_status,
+            release_date, first_release_date, country, label, catalog_number,
+            packaging, media_count, format_summary, metadata_source,
+            metadata_updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(item_id) DO UPDATE SET
+            artist_credit = excluded.artist_credit,
+            musicbrainz_release_id = excluded.musicbrainz_release_id,
+            musicbrainz_release_group_id = excluded.musicbrainz_release_group_id,
+            release_type = excluded.release_type,
+            release_status = excluded.release_status,
+            release_date = excluded.release_date,
+            first_release_date = excluded.first_release_date,
+            country = excluded.country,
+            label = excluded.label,
+            catalog_number = excluded.catalog_number,
+            packaging = excluded.packaging,
+            media_count = excluded.media_count,
+            format_summary = excluded.format_summary,
+            metadata_source = excluded.metadata_source,
+            metadata_updated_at = excluded.metadata_updated_at
+        """,
+        (
+            item_id,
+            release.get("artist_credit"),
+            release.get("musicbrainz_release_id"),
+            release.get("musicbrainz_release_group_id"),
+            release.get("release_type"),
+            release.get("release_status"),
+            release.get("release_date"),
+            release.get("first_release_date"),
+            release.get("country"),
+            release.get("label"),
+            release.get("catalog_number"),
+            release.get("packaging"),
+            release.get("media_count"),
+            release.get("format_summary"),
+            release.get("source") or "musicbrainz",
+            _now(),
+        ),
+    )
+
+    # MusicBrainz owns this hierarchy. Replacing it is safer than diffing a
+    # provider tracklist whose tracks may have been inserted or reordered.
+    db.execute("DELETE FROM music_media WHERE item_id = ?", (item_id,))
+    for medium_index, medium in enumerate(release.get("media") or [], start=1):
+        cursor = db.execute(
+            """
+            INSERT INTO music_media (item_id, position, format, title, track_count)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                item_id,
+                medium.get("position") or medium_index,
+                medium.get("format"),
+                medium.get("title"),
+                medium.get("track_count"),
+            ),
+        )
+        medium_id = cursor.lastrowid
+        for track_index, track in enumerate(medium.get("tracks") or [], start=1):
+            db.execute(
+                """
+                INSERT INTO music_tracks (
+                    medium_id, position, number, title, artist_credit,
+                    duration_ms, musicbrainz_recording_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    medium_id,
+                    track.get("position") or track_index,
+                    track.get("number"),
+                    track.get("title") or "Untitled",
+                    track.get("artist_credit"),
+                    track.get("duration_ms"),
+                    track.get("musicbrainz_recording_id"),
+                ),
+            )
+
+    _link_release_group_siblings(db, item_id, release.get("musicbrainz_release_group_id"))
+
+
+def _link_release_group_siblings(db, item_id: int, release_group_id: str | None) -> None:
+    """Use Shelf's existing format links for releases of the same work."""
+    if not release_group_id:
+        return
+    siblings = db.execute(
+        "SELECT item_id FROM music_releases "
+        "WHERE musicbrainz_release_group_id = ? AND item_id != ?",
+        (release_group_id, item_id),
+    ).fetchall()
+    for row in siblings:
+        a, b = sorted((item_id, row["item_id"]))
+        db.execute(
+            "INSERT OR IGNORE INTO item_links (item_a_id, item_b_id, link_type) "
+            "VALUES (?, ?, 'format')",
+            (a, b),
+        )
+
+
+def get_release(db, item_id: int) -> dict | None:
+    """Hydrate one music release including media, tracks and identifiers."""
+    ensure_schema(db)
+    row = db.execute(
+        "SELECT * FROM music_releases WHERE item_id = ?", (item_id,)
+    ).fetchone()
+    if not row:
+        return None
+    release = dict(row)
+    media_rows = db.execute(
+        "SELECT * FROM music_media WHERE item_id = ? ORDER BY position, id",
+        (item_id,),
+    ).fetchall()
+    media = []
+    for medium_row in media_rows:
+        medium = dict(medium_row)
+        medium["tracks"] = [
+            dict(track)
+            for track in db.execute(
+                "SELECT * FROM music_tracks WHERE medium_id = ? ORDER BY position, id",
+                (medium_row["id"],),
+            ).fetchall()
+        ]
+        media.append(medium)
+    release["media"] = media
+    release["identifiers"] = [
+        dict(identifier)
+        for identifier in db.execute(
+            "SELECT * FROM music_identifiers WHERE item_id = ? "
+            "ORDER BY identifier_type COLLATE NOCASE, value COLLATE NOCASE",
+            (item_id,),
+        ).fetchall()
+    ]
+    return release
+
+
+def add_identifier(
+    db, item_id: int, identifier_type: str, value: str, description: str | None = None
+) -> None:
+    ensure_schema(db)
+    identifier_type = (identifier_type or "").strip()
+    value = (value or "").strip()
+    if not identifier_type or not value:
+        raise ValueError("identifier type and value are required")
+    db.execute(
+        "INSERT OR IGNORE INTO music_identifiers "
+        "(item_id, identifier_type, value, description) VALUES (?, ?, ?, ?)",
+        (item_id, identifier_type, value, (description or "").strip() or None),
+    )
+
+
+def remove_identifier(db, item_id: int, identifier_id: int) -> bool:
+    ensure_schema(db)
+    cursor = db.execute(
+        "DELETE FROM music_identifiers WHERE id = ? AND item_id = ?",
+        (identifier_id, item_id),
+    )
+    return cursor.rowcount > 0

--- a/app/services/music_covers.py
+++ b/app/services/music_covers.py
@@ -1,0 +1,14 @@
+"""Cover Art Archive trust registration for the first-class Music feature."""
+
+from app.services import covers
+
+
+def register_cover_art_archive() -> None:
+    """Allow the provider-owned CAA URL through Shelf's normal cover guard.
+
+    `_download_to_item` still validates the final URL after redirects; Internet
+    Archive's rotating `*.us.archive.org` image hosts are already allow-listed
+    by Shelf, so this adds only the CAA entry point rather than weakening the
+    redirect boundary.
+    """
+    covers.ALLOWED_COVER_DOMAINS.add("coverartarchive.org")

--- a/app/services/musicbrainz.py
+++ b/app/services/musicbrainz.py
@@ -1,0 +1,295 @@
+"""MusicBrainz and Cover Art Archive integration for Shelf music releases.
+
+MusicBrainz is the canonical identity source for music in Shelf. A Shelf
+``items`` row represents an exact catalogued release; ``music_releases`` stores
+that release's MusicBrainz identity and Release Group. Multiple physical or
+digital formats can therefore share a Release Group while retaining distinct
+release metadata and track lists.
+
+All public requests use ``app.services.outbound``. MusicBrainz requires a
+meaningful User-Agent and no more than one request per second for ordinary
+clients; the identifying header lives here and the host interval is supplied
+through Shelf's normal outbound rate-limit configuration.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from app.services import outbound, provider_result
+
+logger = logging.getLogger(__name__)
+
+MUSICBRAINZ_BASE = "https://musicbrainz.org/ws/2"
+COVER_ART_BASE = "https://coverartarchive.org"
+USER_AGENT = "Shelf/1.0 (https://github.com/dgahagan/shelf)"
+
+_RELEASE_INCLUDES = "artist-credits+labels+recordings+release-groups"
+
+
+def _headers() -> dict[str, str]:
+    return {"User-Agent": USER_AGENT, "Accept": "application/json"}
+
+
+def _artist_credit(value: Any) -> str | None:
+    if not isinstance(value, list):
+        return None
+    parts: list[str] = []
+    for credit in value:
+        if not isinstance(credit, dict):
+            continue
+        name = credit.get("name")
+        if not name and isinstance(credit.get("artist"), dict):
+            name = credit["artist"].get("name")
+        if name:
+            parts.append(str(name))
+        join = credit.get("joinphrase")
+        if join:
+            parts.append(str(join))
+    text = "".join(parts).strip()
+    return text or None
+
+
+def _first_label(release: dict) -> tuple[str | None, str | None]:
+    for entry in release.get("label-info") or []:
+        if not isinstance(entry, dict):
+            continue
+        label = entry.get("label") or {}
+        name = label.get("name") if isinstance(label, dict) else None
+        catno = entry.get("catalog-number")
+        if name or catno:
+            return (str(name) if name else None, str(catno) if catno else None)
+    return None, None
+
+
+def _release_group(release: dict) -> tuple[str | None, str | None, str | None]:
+    group = release.get("release-group") or {}
+    if not isinstance(group, dict):
+        return None, None, None
+    secondary = group.get("secondary-types") or []
+    release_type = group.get("primary-type")
+    if secondary:
+        suffix = ", ".join(str(v) for v in secondary if v)
+        if suffix:
+            release_type = f"{release_type} · {suffix}" if release_type else suffix
+    return group.get("id"), release_type, group.get("first-release-date")
+
+
+def _normalise_medium(medium: dict, fallback_position: int) -> dict:
+    tracks: list[dict] = []
+    for index, track in enumerate(medium.get("tracks") or [], start=1):
+        if not isinstance(track, dict):
+            continue
+        recording = track.get("recording") or {}
+        tracks.append({
+            "position": index,
+            # Text deliberately preserves vinyl positions such as A1/B2.
+            "number": str(track.get("number") or index),
+            "title": track.get("title") or recording.get("title") or "Untitled",
+            "artist_credit": _artist_credit(track.get("artist-credit"))
+                or _artist_credit(recording.get("artist-credit")),
+            "duration_ms": track.get("length") or recording.get("length"),
+            "musicbrainz_recording_id": recording.get("id"),
+        })
+    return {
+        "position": medium.get("position") or fallback_position,
+        "format": medium.get("format"),
+        "title": medium.get("title"),
+        "track_count": medium.get("track-count") or len(tracks),
+        "tracks": tracks,
+    }
+
+
+def normalise_release(release: dict) -> dict:
+    """Convert a MusicBrainz release payload into Shelf's music shape."""
+    label, catalog_number = _first_label(release)
+    group_id, release_type, first_release_date = _release_group(release)
+    media = [
+        _normalise_medium(medium, index)
+        for index, medium in enumerate(release.get("media") or [], start=1)
+        if isinstance(medium, dict)
+    ]
+    format_names = [m.get("format") for m in media if m.get("format")]
+    return {
+        "title": release.get("title") or "Untitled",
+        "artist_credit": _artist_credit(release.get("artist-credit")),
+        "musicbrainz_release_id": release.get("id"),
+        "musicbrainz_release_group_id": group_id,
+        "release_type": release_type,
+        "release_status": release.get("status"),
+        "release_date": release.get("date"),
+        "first_release_date": first_release_date,
+        "country": release.get("country"),
+        "label": label,
+        "catalog_number": catalog_number,
+        "barcode": release.get("barcode"),
+        "packaging": release.get("packaging"),
+        "media_count": len(media),
+        "format_summary": ", ".join(dict.fromkeys(format_names)) if format_names else None,
+        "media": media,
+        "source": "musicbrainz",
+    }
+
+
+def _search_summary(release: dict) -> dict:
+    normalised = normalise_release(release)
+    return {
+        key: normalised.get(key)
+        for key in (
+            "title", "artist_credit", "musicbrainz_release_id",
+            "musicbrainz_release_group_id", "release_type", "release_status",
+            "release_date", "country", "label", "catalog_number", "barcode",
+            "packaging", "media_count", "format_summary",
+        )
+    }
+
+
+async def _request_json(
+    client: httpx.AsyncClient,
+    url: str,
+    *,
+    params: dict[str, str] | None = None,
+    provider: str = "musicbrainz",
+) -> provider_result.ProviderResult:
+    try:
+        resp = await outbound.fetch(
+            client,
+            "GET",
+            url,
+            params=params,
+            headers=_headers(),
+            timeout=15,
+        )
+    except (httpx.ConnectError, httpx.TimeoutException):
+        return provider_result.transport_failed(provider)
+    except Exception:
+        logger.debug("%s request failed", provider, exc_info=True)
+        return provider_result.transport_failed(provider)
+
+    classified = provider_result.classify_response(provider, resp)
+    if classified is not None:
+        if resp.status_code == 503:
+            return provider_result.transport_failed(provider)
+        return classified
+    try:
+        return provider_result.found(provider, resp.json(), status=resp.status_code)
+    except ValueError:
+        return provider_result.transport_failed(provider)
+
+
+async def search_releases(
+    query: str,
+    client: httpx.AsyncClient,
+    *,
+    artist: str | None = None,
+    barcode: str | None = None,
+    catalog_number: str | None = None,
+    limit: int = 15,
+) -> provider_result.ProviderResult:
+    """Search exact MusicBrainz releases, not Release Groups."""
+    clauses: list[str] = []
+    if barcode:
+        clauses.append(f'barcode:"{barcode.strip()}"')
+    if catalog_number:
+        clauses.append(f'catno:"{catalog_number.strip()}"')
+    if query and query.strip():
+        clauses.append(f'release:"{query.strip()}"')
+    if artist and artist.strip():
+        clauses.append(f'artist:"{artist.strip()}"')
+    if not clauses:
+        return provider_result.no_match("musicbrainz")
+
+    result = await _request_json(
+        client,
+        f"{MUSICBRAINZ_BASE}/release/",
+        params={
+            "query": " AND ".join(clauses),
+            "fmt": "json",
+            "limit": str(max(1, min(limit, 100))),
+        },
+    )
+    if not result.found:
+        return result
+    releases = result.payload.get("releases") or []
+    return result.with_payload([
+        _search_summary(r) for r in releases if isinstance(r, dict)
+    ])
+
+
+async def search_by_barcode(
+    barcode: str, client: httpx.AsyncClient, *, limit: int = 15
+) -> provider_result.ProviderResult:
+    return await search_releases("", client, barcode=barcode, limit=limit)
+
+
+async def search_by_catalog_number(
+    catalog_number: str,
+    client: httpx.AsyncClient,
+    *,
+    artist: str | None = None,
+    limit: int = 15,
+) -> provider_result.ProviderResult:
+    return await search_releases(
+        "", client, artist=artist, catalog_number=catalog_number, limit=limit
+    )
+
+
+async def lookup_release(
+    release_id: str, client: httpx.AsyncClient
+) -> provider_result.ProviderResult:
+    release_id = (release_id or "").strip()
+    if not release_id:
+        return provider_result.no_match("musicbrainz")
+    result = await _request_json(
+        client,
+        f"{MUSICBRAINZ_BASE}/release/{release_id}",
+        params={"inc": _RELEASE_INCLUDES, "fmt": "json"},
+    )
+    if not result.found:
+        return result
+    if not isinstance(result.payload, dict) or not result.payload.get("id"):
+        return provider_result.no_match("musicbrainz")
+    return result.with_payload(normalise_release(result.payload))
+
+
+async def cover_art(
+    release_id: str, client: httpx.AsyncClient
+) -> provider_result.ProviderResult:
+    """Return Cover Art Archive candidates for one exact MusicBrainz release."""
+    release_id = (release_id or "").strip()
+    if not release_id:
+        return provider_result.no_match("coverartarchive")
+    result = await _request_json(
+        client,
+        f"{COVER_ART_BASE}/release/{release_id}",
+        provider="coverartarchive",
+    )
+    if not result.found:
+        if result.status == 404:
+            return provider_result.found("coverartarchive", [], status=404)
+        return result
+
+    images = result.payload.get("images") or []
+    candidates: list[dict] = []
+    for image in images:
+        if not isinstance(image, dict):
+            continue
+        thumbnails = image.get("thumbnails") or {}
+        full = image.get("image")
+        thumb = thumbnails.get("500") or thumbnails.get("250") or full
+        if not full:
+            continue
+        candidates.append({
+            "url": full,
+            "thumbnail": thumb,
+            "front": bool(image.get("front")),
+            "back": bool(image.get("back")),
+            "types": [str(v) for v in image.get("types") or []],
+            "comment": image.get("comment") or "",
+            "source": "Cover Art Archive",
+        })
+    candidates.sort(key=lambda c: (not c["front"], c["back"]))
+    return result.with_payload(candidates)

--- a/app/templates/music.html
+++ b/app/templates/music.html
@@ -63,7 +63,10 @@
                     {% if user and user.role in ('admin', 'editor') %}
                     <form method="post" action="/api/music/add" class="space-y-2">
                         <input type="hidden" name="release_id" value="{{ release.musicbrainz_release_id }}">
-                        <select name="media_type" class="w-full bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-sm">
+                        <select name="media_type" required class="w-full bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-sm">
+                            {% if not release.shelf_media_type %}
+                            <option value="" selected disabled>Choose format</option>
+                            {% endif %}
                             {% for key, label in music_media_types.items() %}
                             <option value="{{ key }}" {% if key == release.shelf_media_type %}selected{% endif %}>{{ label }}</option>
                             {% endfor %}

--- a/app/templates/music.html
+++ b/app/templates/music.html
@@ -1,0 +1,109 @@
+{% extends "base.html" %}
+{% block title %}Music — Shelf{% endblock %}
+{% block content %}
+<div>
+    <div class="flex items-center justify-between gap-4 mb-6">
+        <div>
+            <p class="text-xs text-shelf-muted">Catalogue</p>
+            <h1 class="text-2xl font-bold mt-1">Music</h1>
+            <p class="text-sm text-shelf-muted mt-1">Search exact MusicBrainz releases and keep the pressing, medium and track list you actually own.</p>
+        </div>
+        <a href="/browse" class="text-sm px-3 py-2 bg-shelf-card border border-shelf-border rounded-lg text-shelf-muted hover:text-shelf-text">Browse all media</a>
+    </div>
+
+    <form method="get" action="/music" class="bg-shelf-card border border-shelf-border rounded-xl p-6 mb-6">
+        <h2 class="text-lg font-semibold mb-4">Find a release</h2>
+        <div class="space-y-3">
+            <div>
+                <label for="music-title" class="block text-sm font-medium text-shelf-muted mb-1">Release title</label>
+                <input id="music-title" name="q" value="{{ q }}" placeholder="Release title" class="w-full bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-shelf-text outline-none">
+            </div>
+            <div>
+                <label for="music-artist" class="block text-sm font-medium text-shelf-muted mb-1">Artist</label>
+                <input id="music-artist" name="artist" value="{{ artist }}" placeholder="Artist" class="w-full bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-shelf-text outline-none">
+            </div>
+            <div>
+                <label for="music-barcode" class="block text-sm font-medium text-shelf-muted mb-1">Barcode</label>
+                <input id="music-barcode" name="barcode" value="{{ barcode }}" inputmode="numeric" placeholder="UPC / EAN" class="w-full bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-shelf-text outline-none">
+            </div>
+            <div>
+                <label for="music-catno" class="block text-sm font-medium text-shelf-muted mb-1">Catalogue number</label>
+                <input id="music-catno" name="catalog_number" value="{{ catalog_number }}" placeholder="Catalogue number" class="w-full bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-shelf-text outline-none">
+            </div>
+        </div>
+        <div class="flex gap-3 mt-4">
+            <button type="submit" class="px-4 py-2 bg-shelf-accent text-white rounded-lg text-sm">Search MusicBrainz</button>
+            {% if q or artist or barcode or catalog_number %}<a href="/music" class="px-4 py-2 text-sm text-shelf-muted hover:text-shelf-text">Clear</a>{% endif %}
+        </div>
+    </form>
+
+    {% if error %}
+    <div role="alert" class="mb-6 rounded-lg border border-shelf-border bg-shelf-card px-4 py-3 text-sm text-shelf-error">{{ error }}</div>
+    {% endif %}
+
+    {% if results %}
+    <section class="mb-6">
+        <h2 class="text-lg font-semibold mb-3">Matching releases</h2>
+        <div class="space-y-3">
+            {% for release in results %}
+            <article class="bg-shelf-card border border-shelf-border rounded-xl p-4">
+                <div class="flex items-start justify-between gap-4">
+                    <div class="min-w-0">
+                        <h3 class="font-semibold">{{ release.title }}</h3>
+                        {% if release.artist_credit %}<p class="text-sm text-shelf-accent2 mt-1">{{ release.artist_credit }}</p>{% endif %}
+                        <p class="text-xs text-shelf-muted mt-2">
+                            {{ release.shelf_media_label }}
+                            {% if release.release_date %} · {{ release.release_date }}{% endif %}
+                            {% if release.country %} · {{ release.country }}{% endif %}
+                            {% if release.label %} · {{ release.label }}{% endif %}
+                            {% if release.catalog_number %} · {{ release.catalog_number }}{% endif %}
+                            {% if release.format_summary %} · {{ release.format_summary }}{% endif %}
+                        </p>
+                    </div>
+                    {% if user and user.role in ('admin', 'editor') %}
+                    <form method="post" action="/api/music/add" class="space-y-2">
+                        <input type="hidden" name="release_id" value="{{ release.musicbrainz_release_id }}">
+                        <select name="media_type" class="w-full bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-sm">
+                            {% for key, label in music_media_types.items() %}
+                            <option value="{{ key }}" {% if key == release.shelf_media_type %}selected{% endif %}>{{ label }}</option>
+                            {% endfor %}
+                        </select>
+                        <select name="location_id" class="w-full bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-sm">
+                            <option value="">No location</option>
+                            {% for loc in locations %}<option value="{{ loc.id }}">{{ loc.name }}</option>{% endfor %}
+                        </select>
+                        <button type="submit" class="w-full px-3 py-2 bg-shelf-accent text-white rounded-lg text-sm">Add release</button>
+                    </form>
+                    {% endif %}
+                </div>
+            </article>
+            {% endfor %}
+        </div>
+    </section>
+    {% endif %}
+
+    <section>
+        <div class="flex items-center justify-between gap-4 mb-3">
+            <h2 class="text-lg font-semibold">Your music</h2>
+            <span class="text-sm text-shelf-muted">{{ items|length }} shown</span>
+        </div>
+        {% if items %}
+        <div class="space-y-2">
+            {% for item in items %}
+            <a href="/music/item/{{ item.id }}" class="block bg-shelf-card border border-shelf-border rounded-lg px-4 py-3 hover:bg-shelf-hover">
+                <div class="flex items-center justify-between gap-4">
+                    <div class="min-w-0">
+                        <p class="font-medium">{{ item.title }}</p>
+                        <p class="text-xs text-shelf-muted mt-1">{% if item.authors %}{{ item.authors }} · {% endif %}{{ music_media_types.get(item.media_type, item.media_type) }}{% if item.release_date %} · {{ item.release_date }}{% elif item.publish_year %} · {{ item.publish_year }}{% endif %}{% if item.catalog_number %} · {{ item.catalog_number }}{% endif %}</p>
+                    </div>
+                    <span class="text-sm text-shelf-muted">View</span>
+                </div>
+            </a>
+            {% endfor %}
+        </div>
+        {% else %}
+        <div class="bg-shelf-card border border-shelf-border rounded-xl p-6 text-sm text-shelf-muted">No music releases are catalogued yet. Search above to add an exact release.</div>
+        {% endif %}
+    </section>
+</div>
+{% endblock %}

--- a/app/templates/music_item.html
+++ b/app/templates/music_item.html
@@ -1,0 +1,74 @@
+{% extends "base.html" %}
+{% block title %}{{ item.title }} — Music — Shelf{% endblock %}
+{% block content %}
+<div>
+    <div class="mb-4">
+        <a href="/music" class="text-sm text-shelf-muted hover:text-shelf-text">&larr; Back to music</a>
+    </div>
+
+    <div class="bg-shelf-card border border-shelf-border rounded-xl p-6">
+        <div class="flex items-start justify-between gap-4 mb-4">
+            <div>
+                <p class="text-xs text-shelf-muted">{{ media_types.get(item.media_type, item.media_type) }}</p>
+                <h1 class="text-2xl font-bold mt-1">{{ item.title }}</h1>
+                {% if item.authors %}<p class="text-shelf-accent2 mt-1">{{ item.authors }}</p>{% endif %}
+            </div>
+            <div class="flex gap-2">
+                <a href="/item/{{ item.id }}" class="px-3 py-2 bg-shelf-bg border border-shelf-border rounded-lg text-sm text-shelf-muted hover:text-shelf-text">Catalogue item</a>
+                {% if release and user and user.role in ('admin', 'editor') %}
+                <form method="post" action="/api/music/items/{{ item.id }}/refresh">
+                    <button type="submit" class="px-3 py-2 bg-shelf-accent text-white rounded-lg text-sm">Refresh metadata</button>
+                </form>
+                {% endif %}
+            </div>
+        </div>
+
+        {% if release %}
+        <div class="space-y-2 text-sm mb-4">
+            {% if release.release_type %}<div><span class="text-shelf-muted">Release:</span> {{ release.release_type }}</div>{% endif %}
+            {% if release.release_date %}<div><span class="text-shelf-muted">Date:</span> {{ release.release_date }}</div>{% endif %}
+            {% if release.country %}<div><span class="text-shelf-muted">Country:</span> {{ release.country }}</div>{% endif %}
+            {% if release.label %}<div><span class="text-shelf-muted">Label:</span> {{ release.label }}</div>{% endif %}
+            {% if release.catalog_number %}<div><span class="text-shelf-muted">Catalogue #:</span> {{ release.catalog_number }}</div>{% endif %}
+            {% if release.format_summary %}<div><span class="text-shelf-muted">Format:</span> {{ release.format_summary }}</div>{% endif %}
+            {% if release.packaging %}<div><span class="text-shelf-muted">Packaging:</span> {{ release.packaging }}</div>{% endif %}
+            {% if item.upc %}<div><span class="text-shelf-muted">Barcode:</span> {{ item.upc }}</div>{% endif %}
+        </div>
+
+        {% if release.media %}
+        <div class="space-y-3">
+            {% for medium in release.media %}
+            <section class="pt-4 border-t border-shelf-border">
+                <div class="flex items-center gap-2 mb-2">
+                    <h2 class="font-semibold">{% if release.media|length > 1 %}Medium {{ medium.position }}{% else %}Track listing{% endif %}</h2>
+                    {% if medium.format %}<span class="text-xs text-shelf-muted">{{ medium.format }}</span>{% endif %}
+                    {% if medium.title %}<span class="text-xs text-shelf-muted">· {{ medium.title }}</span>{% endif %}
+                </div>
+                {% if medium.tracks %}
+                <div class="space-y-2">
+                    {% for track in medium.tracks %}
+                    <div class="flex gap-3 items-center px-3 py-2 text-sm bg-shelf-bg border border-shelf-border rounded-lg">
+                        <span class="shrink-0 text-xs text-shelf-muted">{{ track.number or track.position }}</span>
+                        <div class="min-w-0">
+                            <span>{{ track.title }}</span>
+                            {% if track.artist_credit and track.artist_credit != release.artist_credit %}<span class="text-xs text-shelf-muted"> · {{ track.artist_credit }}</span>{% endif %}
+                        </div>
+                        {% if track.duration_ms %}<span class="text-xs text-shelf-muted">{{ '%d:%02d'|format((track.duration_ms // 1000) // 60, (track.duration_ms // 1000) % 60) }}</span>{% endif %}
+                    </div>
+                    {% endfor %}
+                </div>
+                {% endif %}
+            </section>
+            {% endfor %}
+        </div>
+        {% endif %}
+
+        {% if release.musicbrainz_release_id %}
+        <p class="mt-4 pt-4 border-t border-shelf-border text-xs text-shelf-muted">MusicBrainz release: <a href="https://musicbrainz.org/release/{{ release.musicbrainz_release_id }}" target="_blank" rel="noopener" class="text-shelf-accent2">{{ release.musicbrainz_release_id }}</a></p>
+        {% endif %}
+        {% else %}
+        <div class="bg-shelf-bg border border-shelf-border rounded-lg p-4 text-sm text-shelf-muted">This music item does not have an exact MusicBrainz release attached yet.</div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/docs/user-guide/music.md
+++ b/docs/user-guide/music.md
@@ -1,0 +1,44 @@
+# Music
+
+Shelf can catalogue exact music releases rather than treating a title as one undifferentiated record.
+
+Supported music formats are **Vinyl**, **Cassette**, **CD**, **Digital Music**, and **Other Music Format**. CD reuses Shelf's existing CD media type.
+
+## Add a release
+
+Open **Music** from the navigation bar. Search MusicBrainz by any combination of:
+
+- release title;
+- artist;
+- UPC/EAN barcode;
+- catalogue number.
+
+Shelf searches MusicBrainz **releases**, not only release groups, so different pressings can retain their own country, date, label, catalogue number, packaging and medium format.
+
+Choose the matching result, confirm the Shelf format and optional physical location, then add it.
+
+## Track lists and multi-disc releases
+
+The Music detail page keeps the MusicBrainz medium hierarchy. Multi-disc releases remain separated by medium and vinyl-style track positions such as `A1`, `A2`, `B1` are stored as text instead of being forced into simple integers.
+
+Each track can retain its MusicBrainz recording identity, artist credit and duration.
+
+## Artwork
+
+After adding an exact release, Shelf asks Cover Art Archive for artwork associated with that MusicBrainz release. A front image is preferred. Existing Shelf cover artwork is never overwritten by a refresh.
+
+## Alternate formats
+
+MusicBrainz Release Group identity is stored separately from the exact release identity. If two catalogued releases share a Release Group, Shelf links them using its existing `format` item relationship while preserving each exact release as its own catalogue item.
+
+## Refresh metadata
+
+Editors can refresh an exact release from its Music page. Provider-owned release and track metadata is replaced from MusicBrainz while Shelf's catalogue identity remains the same.
+
+## Physical copies
+
+Release metadata does not store condition, acquisition details or provenance. Those belong to Shelf's physical-copy model, so two physical copies of the same pressing can eventually share one music release record while keeping their own copy-specific state.
+
+## Discogs
+
+Discogs enrichment is intentionally separate from the core Music contribution. MusicBrainz provides the canonical release identity in this feature; Discogs can be added later as optional pressing enrichment without making the core catalogue depend on a Discogs credential.

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -826,7 +826,7 @@ class TestConfirmEndpoint:
 
     def test_unknown_media_type_rejected(self, admin_client):
         resp = admin_client.post("/api/intake/confirm", json={
-            "books": [{"title": "Something", "media_type": "vinyl"}],
+            "books": [{"title": "Something", "media_type": "not-a-media-type"}],
         })
         assert resp.status_code == 422
 

--- a/tests/test_music_foundation.py
+++ b/tests/test_music_foundation.py
@@ -1,6 +1,7 @@
 """Upstream-facing tests for Shelf's first-class music foundation."""
 
 from app.config import MEDIA_TYPES, MUSIC_MEDIA_TYPES
+from app.routers import music
 from app.services import music_catalog, musicbrainz
 from app.services.item_write import insert_item
 
@@ -52,11 +53,15 @@ _SAMPLE_RELEASE = {
 
 
 def test_music_media_family_reuses_existing_cd_type():
-    assert MUSIC_MEDIA_TYPES == {
-        "vinyl", "cassette", "cd", "digital_music", "music_other"
-    }
+    assert MUSIC_MEDIA_TYPES == {"vinyl", "cassette", "cd", "digital_music"}
     assert MUSIC_MEDIA_TYPES <= MEDIA_TYPES.keys()
+    assert "music_other" not in MEDIA_TYPES
     assert MEDIA_TYPES["cd"] == "CD"
+
+
+def test_unknown_musicbrainz_format_requires_user_choice():
+    release = {"format_summary": "MiniDisc", "media": [{"format": "MiniDisc"}]}
+    assert music._infer_media_type(release) is None
 
 
 def test_music_schema_is_idempotent_and_keeps_track_numbers_as_text(db):

--- a/tests/test_music_foundation.py
+++ b/tests/test_music_foundation.py
@@ -1,0 +1,174 @@
+"""Upstream-facing tests for Shelf's first-class music foundation."""
+
+from app.config import MEDIA_TYPES, MUSIC_MEDIA_TYPES
+from app.services import music_catalog, musicbrainz
+from app.services.item_write import insert_item
+
+
+_SAMPLE_RELEASE = {
+    "title": "The Dark Side of the Moon",
+    "artist_credit": "Pink Floyd",
+    "musicbrainz_release_id": "11111111-1111-1111-1111-111111111111",
+    "musicbrainz_release_group_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    "release_type": "Album",
+    "release_status": "Official",
+    "release_date": "1973-03-23",
+    "first_release_date": "1973-03-01",
+    "country": "GB",
+    "label": "Harvest",
+    "catalog_number": "SHVL 804",
+    "barcode": None,
+    "packaging": "Gatefold Cover",
+    "media_count": 1,
+    "format_summary": "12\" Vinyl",
+    "source": "musicbrainz",
+    "media": [
+        {
+            "position": 1,
+            "format": "12\" Vinyl",
+            "title": None,
+            "track_count": 2,
+            "tracks": [
+                {
+                    "position": 1,
+                    "number": "A1",
+                    "title": "Speak to Me",
+                    "artist_credit": "Pink Floyd",
+                    "duration_ms": 65000,
+                    "musicbrainz_recording_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                },
+                {
+                    "position": 2,
+                    "number": "B1",
+                    "title": "Money",
+                    "artist_credit": "Pink Floyd",
+                    "duration_ms": 382000,
+                    "musicbrainz_recording_id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+                },
+            ],
+        }
+    ],
+}
+
+
+def test_music_media_family_reuses_existing_cd_type():
+    assert MUSIC_MEDIA_TYPES == {
+        "vinyl", "cassette", "cd", "digital_music", "music_other"
+    }
+    assert MUSIC_MEDIA_TYPES <= MEDIA_TYPES.keys()
+    assert MEDIA_TYPES["cd"] == "CD"
+
+
+def test_music_schema_is_idempotent_and_keeps_track_numbers_as_text(db):
+    music_catalog.ensure_schema(db)
+    music_catalog.ensure_schema(db)
+
+    names = {
+        row["name"]
+        for row in db.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+    }
+    assert {"music_releases", "music_media", "music_tracks", "music_identifiers"} <= names
+    columns = {
+        row["name"]: row["type"]
+        for row in db.execute("PRAGMA table_info(music_tracks)").fetchall()
+    }
+    assert columns["number"].upper() == "TEXT"
+
+    release_columns = {
+        row["name"] for row in db.execute("PRAGMA table_info(music_releases)").fetchall()
+    }
+    assert "media_condition" not in release_columns
+    assert "condition_notes" not in release_columns
+
+
+def test_musicbrainz_normalisation_preserves_vinyl_side_numbering():
+    raw = {
+        "id": _SAMPLE_RELEASE["musicbrainz_release_id"],
+        "title": _SAMPLE_RELEASE["title"],
+        "artist-credit": [
+            {"name": "Pink Floyd", "artist": {"name": "Pink Floyd"}, "joinphrase": ""}
+        ],
+        "status": "Official",
+        "date": "1973-03-23",
+        "country": "GB",
+        "packaging": "Gatefold Cover",
+        "release-group": {
+            "id": _SAMPLE_RELEASE["musicbrainz_release_group_id"],
+            "primary-type": "Album",
+            "first-release-date": "1973-03-01",
+        },
+        "label-info": [
+            {"catalog-number": "SHVL 804", "label": {"name": "Harvest"}}
+        ],
+        "media": [
+            {
+                "position": 1,
+                "format": "12\" Vinyl",
+                "track-count": 2,
+                "tracks": [
+                    {
+                        "position": 1,
+                        "number": "A1",
+                        "title": "Speak to Me",
+                        "length": 65000,
+                        "recording": {"id": "rec-a", "title": "Speak to Me"},
+                    },
+                    {
+                        "position": 2,
+                        "number": "B1",
+                        "title": "Money",
+                        "length": 382000,
+                        "recording": {"id": "rec-b", "title": "Money"},
+                    },
+                ],
+            }
+        ],
+    }
+
+    release = musicbrainz.normalise_release(raw)
+    assert release["musicbrainz_release_group_id"] == raw["release-group"]["id"]
+    assert release["artist_credit"] == "Pink Floyd"
+    assert release["catalog_number"] == "SHVL 804"
+    assert [track["number"] for track in release["media"][0]["tracks"]] == ["A1", "B1"]
+
+
+def test_release_media_tracks_and_identifiers_round_trip(db):
+    item_id = insert_item(
+        db,
+        title=_SAMPLE_RELEASE["title"],
+        authors="Pink Floyd",
+        media_type="vinyl",
+        source="musicbrainz",
+    )
+    music_catalog.save_release(db, item_id, _SAMPLE_RELEASE)
+    music_catalog.add_identifier(
+        db, item_id, "matrix_runout", "SHVL 804 A-2", "Side A"
+    )
+
+    release = music_catalog.get_release(db, item_id)
+    assert release["catalog_number"] == "SHVL 804"
+    assert release["media"][0]["format"] == "12\" Vinyl"
+    assert [track["number"] for track in release["media"][0]["tracks"]] == ["A1", "B1"]
+    assert release["identifiers"][0]["value"] == "SHVL 804 A-2"
+
+
+def test_same_release_group_links_different_formats(db):
+    vinyl_id = insert_item(db, title="Album", media_type="vinyl")
+    cd_id = insert_item(db, title="Album", media_type="cd")
+
+    vinyl = dict(_SAMPLE_RELEASE)
+    cd = dict(_SAMPLE_RELEASE)
+    cd["musicbrainz_release_id"] = "22222222-2222-2222-2222-222222222222"
+    cd["format_summary"] = "CD"
+    cd["media"] = []
+
+    music_catalog.save_release(db, vinyl_id, vinyl)
+    music_catalog.save_release(db, cd_id, cd)
+
+    a, b = sorted((vinyl_id, cd_id))
+    link = db.execute(
+        "SELECT link_type FROM item_links WHERE item_a_id = ? AND item_b_id = ?",
+        (a, b),
+    ).fetchone()
+    assert link is not None
+    assert link["link_type"] == "format"

--- a/tests/test_music_full_integration.py
+++ b/tests/test_music_full_integration.py
@@ -1,0 +1,46 @@
+"""Focused regressions for the complete first-class Music surface."""
+
+from pathlib import Path
+
+from app.config import MEDIA_TYPES, MUSIC_MEDIA_TYPES
+from app.routers import music
+
+
+def test_music_family_is_first_class():
+    assert MUSIC_MEDIA_TYPES == {
+        "vinyl",
+        "cassette",
+        "cd",
+        "digital_music",
+        "music_other",
+    }
+    assert MUSIC_MEDIA_TYPES <= set(MEDIA_TYPES)
+
+
+def test_music_router_exposes_browse_add_detail_and_refresh():
+    paths = {(route.path, ",".join(sorted(route.methods or []))) for route in music.router.routes}
+    assert ("/music", "GET") in paths
+    assert ("/api/music/add", "POST") in paths
+    assert ("/music/item/{item_id}", "GET") in paths
+    assert ("/api/music/items/{item_id}/refresh", "POST") in paths
+
+
+def test_musicbrainz_formats_map_conservatively():
+    assert music._infer_media_type({"media": [{"format": "12\" Vinyl"}]}) == "vinyl"
+    assert music._infer_media_type({"media": [{"format": "Cassette"}]}) == "cassette"
+    assert music._infer_media_type({"media": [{"format": "CD"}]}) == "cd"
+    assert music._infer_media_type({"media": [{"format": "Digital Media"}]}) == "digital_music"
+    assert music._infer_media_type({"media": [{"format": "MiniDisc"}]}) == "music_other"
+
+
+def test_music_templates_keep_exact_release_workflow_visible():
+    root = Path(__file__).parents[1] / "app" / "templates"
+    library = (root / "music.html").read_text()
+    detail = (root / "music_item.html").read_text()
+
+    assert 'action="/api/music/add"' in library
+    assert "Search MusicBrainz" in library
+    assert 'href="/music/item/{{ item.id }}"' in library
+    assert 'action="/api/music/items/{{ item.id }}/refresh"' in detail
+    assert "Track listing" in detail
+    assert "musicbrainz.org/release/" in detail


### PR DESCRIPTION
<!--
Thanks for contributing to Shelf! For anything bigger than a small fix,
please open an issue first so we can talk about the approach before you
invest time — see CONTRIBUTING.md.
-->

## What this changes

<!-- A sentence or two. If it fixes an open issue, add "Fixes #123". -->

## Why

<!-- What problem does this solve? For a bug, what was the user-visible
     symptom? Skip if the "what" already makes it obvious. -->

## How it was tested

<!-- Which of the checks below you ran, plus anything you exercised by hand
     (which browser, which device, which scanner). -->

- [ ] `make test` passes
- [ ] `make test-e2e` passes
- [ ] `make checks` passes
- [ ] `make css` re-run, if templates or Tailwind classes changed

## Notes for review

<!-- Anything you're unsure about, deliberately left out, or want a second
     opinion on. Screenshots or a short clip help a lot for UI changes. -->

---

A few project-specific things that are easy to trip over — see `GOTCHAS.md`:

- Unit and E2E tests **cannot** share a pytest invocation; use the Make targets.
- Raw `fetch()` calls must send the `X-CSRF-Token` header (`make check-csrf`).
- Templates must stay compatible with the Alpine.js **CSP build**
  (`make check-alpine`) — nested or bracketed `x-model` bindings silently
  drop input.
- `MIGRATIONS` in `app/database.py` is append-only. Never edit or reorder an
  existing entry; add a new one at the end.
- No CDN references — all JS and CSS is vendored in `static/`.
