### PR TITLE
EDITING: expose manual cover URL in Artwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Shelf are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- **Manual cover URLs are now available directly in Edit → Artwork.** Paste a
+  public HTTPS image URL and choose **Use URL** to apply it immediately through
+  Shelf's existing SSRF-safe manual-cover downloader. The action stays on the
+  edit page, so unsaved metadata is not discarded; normal file uploads and
+  other item edits still wait for **Save Changes**.
+
 ## [0.36.0] - 2026-09-07
 
 Shelf's locations were one flat list. *Office*, *Bookcase 1* and *Shelf 3* sat

--- a/app/routers/items_covers.py
+++ b/app/routers/items_covers.py
@@ -230,6 +230,7 @@ async def cover_select(
 async def cover_from_url(
     item_id: int,
     url: str = Form(...),
+    return_to: str | None = Form(None),
     _=Depends(require_role("editor")),
 ):
     """Use a user-pasted public HTTPS image as an item's cover."""
@@ -254,7 +255,8 @@ async def cover_from_url(
         )
     resp = HTMLResponse("")
     resp.headers["HX-Trigger"] = items_common._toast_header("Cover updated")
-    resp.headers["HX-Redirect"] = f"/item/{item_id}"
+    if return_to != "edit":
+        resp.headers["HX-Redirect"] = f"/item/{item_id}"
     return resp
 
 

--- a/app/templates/item_edit.html
+++ b/app/templates/item_edit.html
@@ -141,7 +141,7 @@
         <section id="edit-artwork" data-testid="edit-section-artwork" class="bg-shelf-card rounded-xl border border-shelf-border p-6 space-y-4">
             <div>
                 <h2 class="text-lg font-semibold">Artwork</h2>
-                <p class="text-sm text-shelf-muted mt-1">Preview the current cover or upload a replacement.</p>
+                <p class="text-sm text-shelf-muted mt-1">Preview the current cover, upload a replacement, or use a public image URL.</p>
             </div>
 
             <div x-data="coverDrop">
@@ -165,6 +165,25 @@
                         <p class="text-xs text-shelf-muted mt-1">The replacement is applied when you save the item.</p>
                     </div>
                 </div>
+            </div>
+
+            <div class="border-t border-shelf-border pt-4 space-y-2">
+                <label for="edit-cover-url" class="block text-sm font-medium text-shelf-muted">Cover image URL</label>
+                <div class="flex flex-col sm:flex-row gap-2">
+                    <input type="url" id="edit-cover-url" name="url" inputmode="url" autocomplete="url"
+                           placeholder="https://example.com/cover.jpg"
+                           class="min-w-0 flex-1 bg-shelf-bg border border-shelf-border rounded-lg px-3 py-2 text-shelf-text focus:ring-2 focus:ring-shelf-accent focus:border-transparent outline-none placeholder-shelf-muted/50">
+                    <button type="button" data-testid="edit-cover-url-submit"
+                            hx-post="/api/items/{{ item.id }}/cover-url"
+                            hx-include="#edit-cover-url"
+                            hx-vals='{"return_to":"edit"}'
+                            hx-swap="none"
+                            hx-disabled-elt="this, #edit-cover-url"
+                            class="px-4 py-2 bg-shelf-hover text-shelf-text border border-shelf-border rounded-lg text-sm hover:border-shelf-accent/50 transition-colors whitespace-nowrap">
+                        Use URL
+                    </button>
+                </div>
+                <p class="text-xs text-shelf-muted">Public HTTPS image links only. Use URL applies the cover immediately; your other edits are still saved with Save Changes.</p>
             </div>
         </section>
 

--- a/tests/test_item_edit_sections.py
+++ b/tests/test_item_edit_sections.py
@@ -42,3 +42,13 @@ def test_item_edit_is_sectioned_without_changing_the_save_contract():
     assert 'data-media-types="video_game audiobook"' in template
     assert "updateEditSectionVisibility" in script
     assert "mediaSelect.addEventListener('change'" in script
+
+    # Artwork exposes the existing safe manual-cover URL route directly from
+    # Edit without nesting another form inside the item-save form. The HTMX
+    # action applies only the cover and deliberately stays on the edit page so
+    # unsaved metadata remains in the DOM.
+    assert 'id="edit-cover-url"' in template
+    assert 'data-testid="edit-cover-url-submit"' in template
+    assert 'hx-post="/api/items/{{ item.id }}/cover-url"' in template
+    assert 'hx-include="#edit-cover-url"' in template
+    assert 'hx-vals=\'{"return_to":"edit"}\'' in template

--- a/tests/test_manual_cover_url.py
+++ b/tests/test_manual_cover_url.py
@@ -161,3 +161,30 @@ def test_redirect_target_is_validated_as_a_new_hop(monkeypatch):
         "https://covers.example.test/start.jpg",
         "https://127.0.0.1/private.jpg",
     ]
+
+
+def test_manual_url_from_edit_preserves_unsaved_edit_page(editor_client, db, monkeypatch):
+    from app.services import manual_cover
+
+    item_id = _insert_item(db, title="Edit manual cover", isbn="9780900011005")
+    db.commit()
+    monkeypatch.setattr(
+        manual_cover,
+        "download",
+        AsyncMock(return_value=f"covers/{item_id}.jpg"),
+    )
+
+    resp = editor_client.post(
+        f"/api/items/{item_id}/cover-url",
+        data={
+            "url": "https://images.example.test/edit-cover.jpg",
+            "return_to": "edit",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert "HX-Redirect" not in resp.headers
+    assert "Cover updated" in resp.headers.get("HX-Trigger", "")
+    row = db.execute("SELECT cover_path FROM items WHERE id = ?", (item_id,)).fetchone()
+    assert row["cover_path"] == f"covers/{item_id}.jpg"
+


### PR DESCRIPTION
## What this changes

Makes Shelf's existing secure manual-cover URL action available where users expect it: **Edit → Artwork**.

- adds a Cover image URL field and explicit **Use URL** action to the existing Artwork section;
- reuses Shelf's existing SSRF-safe `manual_cover` downloader rather than introducing a second download path;
- applies the selected cover immediately without submitting the main item-edit form;
- suppresses the normal item-detail `HX-Redirect` when the action originates from Edit, so unrelated unsaved edits remain in the DOM;
- leaves the existing item-detail cover-picker behaviour unchanged;
- keeps the URL input out of the normal item-write whitelist and explicitly includes only that value in the HTMX action, avoiding nested forms or a second metadata persistence path.

## Why

Shelf already supported downloading a cover from a URL, but the control was not exposed from the sectioned item editor. Users editing artwork therefore had file upload available in the obvious place while the existing manual-URL capability was effectively hidden elsewhere.

## How it was tested

Focused regressions cover the Edit markup and redirect-preservation behaviour. The current upstream CI run is green.

- [x] `make test` passes
- [x] `make test-e2e` passes
- [x] `make checks` passes
- [x] `make css` re-run

## Notes for review

This is deliberately a small UI exposure of an existing hardened backend. It does not add a new cover-fetch implementation or change ordinary item-edit persistence.