### PR TITLE
RELATED MEDIA: add connected item-link groups

### DIFF
--- a/app/services/media_groups.py
+++ b/app/services/media_groups.py
@@ -115,18 +115,20 @@ def search_candidates(db, item_id: int, query: str, *, limit: int = 20):
     """Find catalogue items not already in this item's related-media group."""
     if not db.execute("SELECT 1 FROM items WHERE id = ?", (item_id,)).fetchone():
         return []
-    excluded = set(related_ids(db, item_id, include_self=True))
+    excluded = sorted(related_ids(db, item_id, include_self=True))
     q = (query or "").strip()
     if not q:
         return []
     like = f"%{q}%"
+    placeholders = ",".join("?" for _ in excluded)
     rows = db.execute(
-        """SELECT * FROM items
-           WHERE title LIKE ? COLLATE NOCASE
-              OR authors LIKE ? COLLATE NOCASE
-              OR series_name LIKE ? COLLATE NOCASE
-           ORDER BY title COLLATE NOCASE, media_type, id
-           LIMIT 100""",
-        (like, like, like),
+        f"""SELECT * FROM items
+            WHERE (title LIKE ? COLLATE NOCASE
+               OR authors LIKE ? COLLATE NOCASE
+               OR series_name LIKE ? COLLATE NOCASE)
+              AND id NOT IN ({placeholders})
+            ORDER BY title COLLATE NOCASE, media_type, id
+            LIMIT ?""",
+        (like, like, like, *excluded, limit),
     ).fetchall()
-    return [row for row in rows if row["id"] not in excluded][:limit]
+    return rows

--- a/app/services/media_groups.py
+++ b/app/services/media_groups.py
@@ -1,0 +1,132 @@
+"""Related-media groups built from Shelf's existing ``item_links`` graph.
+
+A group is the connected component of item links, not a second collection
+record. That means A↔B and B↔C naturally presents A/B/C as one related-media
+group without duplicating membership state.
+
+This foundation is intentionally manual-first. Automatic matching by title,
+ISBN or provider identity can be layered on later with stronger evidence;
+cross-media relationships such as a novel and its film adaptation should
+never be guessed from a title alone.
+"""
+
+from __future__ import annotations
+
+
+LINK_TYPES = frozenset({"format", "related", "adaptation"})
+
+
+def link_items(
+    db,
+    item_a_id: int,
+    item_b_id: int,
+    *,
+    link_type: str = "related",
+) -> bool:
+    """Create one undirected item link, returning True only when newly added."""
+    if item_a_id == item_b_id:
+        return False
+    if link_type not in LINK_TYPES:
+        raise ValueError("Unknown related-media link type")
+
+    rows = db.execute(
+        "SELECT id FROM items WHERE id IN (?, ?)", (item_a_id, item_b_id)
+    ).fetchall()
+    if {row["id"] for row in rows} != {item_a_id, item_b_id}:
+        return False
+
+    a_id, b_id = sorted((item_a_id, item_b_id))
+    cursor = db.execute(
+        "INSERT OR IGNORE INTO item_links (item_a_id, item_b_id, link_type) "
+        "VALUES (?, ?, ?)",
+        (a_id, b_id, link_type),
+    )
+    return bool(cursor.rowcount)
+
+
+def unlink_items(db, item_a_id: int, item_b_id: int) -> bool:
+    """Remove the direct edge between two items, regardless of orientation."""
+    if item_a_id == item_b_id:
+        return False
+    a_id, b_id = sorted((item_a_id, item_b_id))
+    cursor = db.execute(
+        "DELETE FROM item_links WHERE item_a_id = ? AND item_b_id = ?",
+        (a_id, b_id),
+    )
+    return bool(cursor.rowcount)
+
+
+def related_ids(db, item_id: int, *, include_self: bool = False) -> list[int]:
+    """Return the full transitive item-link component containing ``item_id``."""
+    if not db.execute("SELECT 1 FROM items WHERE id = ?", (item_id,)).fetchone():
+        return []
+
+    rows = db.execute(
+        """WITH RECURSIVE connected(id) AS (
+               SELECT ?
+               UNION
+               SELECT CASE
+                        WHEN il.item_a_id = connected.id THEN il.item_b_id
+                        ELSE il.item_a_id
+                      END
+               FROM item_links il
+               JOIN connected
+                 ON il.item_a_id = connected.id OR il.item_b_id = connected.id
+           )
+           SELECT id FROM connected ORDER BY id""",
+        (item_id,),
+    ).fetchall()
+    ids = [row["id"] for row in rows]
+    if not include_self:
+        ids = [value for value in ids if value != item_id]
+    return ids
+
+
+def related_items(db, item_id: int, *, include_self: bool = False):
+    """Hydrate a related-media component in stable display order."""
+    ids = related_ids(db, item_id, include_self=include_self)
+    if not ids:
+        return []
+    placeholders = ",".join("?" for _ in ids)
+    return db.execute(
+        f"SELECT * FROM items WHERE id IN ({placeholders}) "
+        "ORDER BY title COLLATE NOCASE, media_type, id",
+        tuple(ids),
+    ).fetchall()
+
+
+def direct_links(db, item_id: int) -> list[dict]:
+    """Return direct neighbours and edge types for edit/detail UIs."""
+    rows = db.execute(
+        """SELECT il.link_type,
+                  CASE WHEN il.item_a_id = ? THEN il.item_b_id ELSE il.item_a_id END AS item_id,
+                  i.title, i.media_type, i.cover_path
+           FROM item_links il
+           JOIN items i ON i.id = CASE
+               WHEN il.item_a_id = ? THEN il.item_b_id ELSE il.item_a_id END
+           WHERE il.item_a_id = ? OR il.item_b_id = ?
+           ORDER BY i.title COLLATE NOCASE, i.media_type, i.id""",
+        (item_id, item_id, item_id, item_id),
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def search_candidates(db, item_id: int, query: str, *, limit: int = 20):
+    """Find catalogue items not already in this item's related-media group."""
+    if not db.execute("SELECT 1 FROM items WHERE id = ?", (item_id,)).fetchone():
+        return []
+    excluded = set(related_ids(db, item_id, include_self=True))
+    q = (query or "").strip()
+    if not q:
+        return []
+    like = f"%{q}%"
+    rows = db.execute(
+        """SELECT * FROM items
+           WHERE title LIKE ? COLLATE NOCASE
+              OR authors LIKE ? COLLATE NOCASE
+              OR series_name LIKE ? COLLATE NOCASE
+           ORDER BY title COLLATE NOCASE, media_type, id
+           LIMIT 100""",
+        (like, like, like),
+    ).fetchall()
+    return [row for row in rows if row["id"] not in excluded][:limit]

--- a/tests/test_media_groups.py
+++ b/tests/test_media_groups.py
@@ -1,0 +1,88 @@
+"""Tests for related-media groups built from the existing item_links graph."""
+
+import pytest
+
+from app.services import media_groups
+from app.services.item_write import insert_item
+
+
+def test_link_is_undirected_and_idempotent(db):
+    a = insert_item(db, title="Dune", media_type="book")
+    b = insert_item(db, title="Dune", media_type="dvd")
+
+    assert media_groups.link_items(db, b, a, link_type="adaptation") is True
+    assert media_groups.link_items(db, a, b, link_type="adaptation") is False
+
+    row = db.execute("SELECT item_a_id, item_b_id, link_type FROM item_links").fetchone()
+    assert tuple(row) == (min(a, b), max(a, b), "adaptation")
+
+
+def test_self_links_and_missing_items_are_not_created(db):
+    item_id = insert_item(db, title="One")
+    assert media_groups.link_items(db, item_id, item_id) is False
+    assert media_groups.link_items(db, item_id, 999999) is False
+    assert db.execute("SELECT COUNT(*) AS c FROM item_links").fetchone()["c"] == 0
+
+
+def test_unknown_link_type_is_rejected(db):
+    a = insert_item(db, title="A")
+    b = insert_item(db, title="B")
+    with pytest.raises(ValueError, match="Unknown related-media"):
+        media_groups.link_items(db, a, b, link_type="guess")
+
+
+def test_group_is_full_transitive_connected_component(db):
+    a = insert_item(db, title="A")
+    b = insert_item(db, title="B")
+    c = insert_item(db, title="C")
+    d = insert_item(db, title="D")
+
+    media_groups.link_items(db, a, b, link_type="format")
+    media_groups.link_items(db, b, c, link_type="related")
+
+    assert media_groups.related_ids(db, a) == [b, c]
+    assert media_groups.related_ids(db, c) == [a, b]
+    assert media_groups.related_ids(db, b, include_self=True) == [a, b, c]
+    assert media_groups.related_ids(db, d) == []
+
+
+def test_direct_links_preserve_relationship_type(db):
+    book = insert_item(db, title="Dune", media_type="book")
+    ebook = insert_item(db, title="Dune eBook", media_type="ebook")
+    film = insert_item(db, title="Dune Film", media_type="dvd")
+
+    media_groups.link_items(db, book, ebook, link_type="format")
+    media_groups.link_items(db, book, film, link_type="adaptation")
+
+    links = media_groups.direct_links(db, book)
+    assert [(row["title"], row["link_type"]) for row in links] == [
+        ("Dune eBook", "format"),
+        ("Dune Film", "adaptation"),
+    ]
+
+
+def test_unlink_can_split_a_component(db):
+    a = insert_item(db, title="A")
+    b = insert_item(db, title="B")
+    c = insert_item(db, title="C")
+    media_groups.link_items(db, a, b)
+    media_groups.link_items(db, b, c)
+
+    assert media_groups.unlink_items(db, b, c) is True
+    assert media_groups.related_ids(db, a) == [b]
+    assert media_groups.related_ids(db, c) == []
+
+
+def test_search_excludes_every_item_already_in_the_group(db):
+    anchor = insert_item(db, title="The Hobbit", authors="J. R. R. Tolkien")
+    ebook = insert_item(db, title="The Hobbit eBook", authors="J. R. R. Tolkien", media_type="ebook")
+    candidate = insert_item(db, title="The Hobbit Film", media_type="dvd")
+    unrelated = insert_item(db, title="Dune", media_type="book")
+    media_groups.link_items(db, anchor, ebook, link_type="format")
+
+    results = media_groups.search_candidates(db, anchor, "Hobbit")
+    ids = [row["id"] for row in results]
+    assert candidate in ids
+    assert anchor not in ids
+    assert ebook not in ids
+    assert unrelated not in ids


### PR DESCRIPTION
## What this changes

Adds the model foundation for explicitly relating different Shelf catalogue records without introducing another grouping table.

It builds on Shelf's existing `item_links` graph:

- stores relationships as canonical undirected edges;
- supports `format`, `related` and `adaptation` relationship types;
- traverses connected components so a group can contain more than two records;
- preserves the direct relationship type between linked items;
- allows unlinking to split a group naturally;
- excludes the existing connected component when searching for new candidates.

## Why

The same work can exist in multiple forms — for example a book, audiobook, film adaptation and digital edition — while each still needs to remain a distinct Shelf catalogue record.

Using the existing item-link graph gives Shelf that relationship layer without conflating editions, copies or media types and without introducing a second competing grouping model.

## How it was tested

Focused tests cover canonical links, connected-component traversal, relationship types, unlink/split behaviour and candidate exclusion. Upstream CI is green.

- [x] `make test` passes
- [x] `make test-e2e` passes
- [x] `make checks` passes
- [x] `make css` passes

## Notes for review

The model is deliberately manual-first. It does not infer relationships from matching titles or other weak metadata. A separate UI contribution can build on this foundation.