### PR TITLE
Add per-library permission foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Release](https://img.shields.io/github/v/release/dgahagan/shelf)](https://github.com/dgahagan/shelf/releases)
 [![Docker Pulls](https://img.shields.io/docker/pulls/dangahagan/shelf)](https://hub.docker.com/r/dangahagan/shelf)
 [![CI](https://github.com/dgahagan/shelf/actions/workflows/test.yml/badge.svg)](https://github.com/dgahagan/shelf/actions/workflows/test.yml)
-[![Unit tests](https://img.shields.io/badge/unit%20tests-2984%20passing-brightgreen)](https://github.com/dgahagan/shelf/actions/workflows/test.yml)
+[![Unit tests](https://img.shields.io/badge/unit%20tests-2996%20passing-brightgreen)](https://github.com/dgahagan/shelf/actions/workflows/test.yml)
 [![E2E tests](https://img.shields.io/badge/e2e%20tests-230%20passing-brightgreen)](https://github.com/dgahagan/shelf/actions/workflows/test.yml)
 [![License: AGPL-3.0](https://img.shields.io/github/license/dgahagan/shelf)](LICENSE)
 

--- a/app/database.py
+++ b/app/database.py
@@ -182,6 +182,43 @@ MIGRATIONS: Sequence[tuple[int, str, str]] = (
      "ALTER TABLE item_copies ADD COLUMN position_order INTEGER DEFAULT NULL"),
     (32, "Add durable cover-review dismissal",
      "ALTER TABLE items ADD COLUMN cover_review_dismissed INTEGER NOT NULL DEFAULT 0"),
+    (33, "Add Shelf libraries",
+     """CREATE TABLE IF NOT EXISTS libraries (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            name          TEXT NOT NULL UNIQUE COLLATE NOCASE,
+            description   TEXT,
+            is_archived   INTEGER NOT NULL DEFAULT 0 CHECK(is_archived IN (0,1)),
+            created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+        )"""),
+    (34, "Add per-library user memberships",
+     """CREATE TABLE IF NOT EXISTS library_memberships (
+            library_id    INTEGER NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
+            user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            role          TEXT NOT NULL CHECK(role IN ('viewer','editor')),
+            created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (library_id, user_id)
+        )"""),
+    (35, "Add one-library-per-item mapping",
+     """CREATE TABLE IF NOT EXISTS library_items (
+            item_id       INTEGER PRIMARY KEY REFERENCES items(id) ON DELETE CASCADE,
+            library_id    INTEGER NOT NULL REFERENCES libraries(id) ON DELETE RESTRICT,
+            created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+        )"""),
+    (36, "Create default Main Library",
+     "INSERT OR IGNORE INTO libraries (id, name, description) "
+     "VALUES (1, 'Main Library', 'Default library created during upgrade')"),
+    (37, "Assign existing catalogue items to Main Library",
+     "INSERT OR IGNORE INTO library_items (item_id, library_id) "
+     "SELECT id, 1 FROM items"),
+    (38, "Seed Main Library memberships from existing roles",
+     """INSERT OR IGNORE INTO library_memberships (library_id, user_id, role)
+        SELECT 1, id, role FROM users WHERE role IN ('viewer','editor')"""),
+    (39, "Index library memberships by user",
+     "CREATE INDEX IF NOT EXISTS idx_library_memberships_user ON library_memberships(user_id)"),
+    (40, "Index catalogue items by library",
+     "CREATE INDEX IF NOT EXISTS idx_library_items_library ON library_items(library_id)"),
 )
 
 MIGRATION_TABLES = """
@@ -290,6 +327,36 @@ CREATE TABLE IF NOT EXISTS users (
     created_at     TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at     TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+-- First-class Shelf libraries and per-library permissions. These definitions
+-- mirror migrations 33-35 so fresh databases and upgraded databases converge.
+CREATE TABLE IF NOT EXISTS libraries (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    name          TEXT NOT NULL UNIQUE COLLATE NOCASE,
+    description   TEXT,
+    is_archived   INTEGER NOT NULL DEFAULT 0 CHECK(is_archived IN (0,1)),
+    created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS library_memberships (
+    library_id    INTEGER NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
+    user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role          TEXT NOT NULL CHECK(role IN ('viewer','editor')),
+    created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (library_id, user_id)
+);
+CREATE INDEX IF NOT EXISTS idx_library_memberships_user
+    ON library_memberships(user_id);
+
+CREATE TABLE IF NOT EXISTS library_items (
+    item_id       INTEGER PRIMARY KEY REFERENCES items(id) ON DELETE CASCADE,
+    library_id    INTEGER NOT NULL REFERENCES libraries(id) ON DELETE RESTRICT,
+    created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_library_items_library
+    ON library_items(library_id);
 
 CREATE TABLE IF NOT EXISTS game_platforms (
     id         INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/app/routers/auth_routes.py
+++ b/app/routers/auth_routes.py
@@ -11,6 +11,7 @@ from app.auth import (
 )
 from app.config import get_client_ip
 from app.database import get_db
+from app.services import libraries
 
 logger = logging.getLogger(__name__)
 
@@ -170,10 +171,14 @@ async def create_user(
 
     try:
         with get_db() as db:
-            db.execute(
+            cursor = db.execute(
                 "INSERT INTO users (username, password, display_name, role) VALUES (?, ?, ?, ?)",
                 (username, hash_password(password), display_name, role),
             )
+            if role in ("viewer", "editor"):
+                libraries.set_membership(
+                    db, libraries.DEFAULT_LIBRARY_ID, cursor.lastrowid, role
+                )
     except sqlite3.IntegrityError:
         logger.warning("Failed to create user '%s': username already exists", username)
         return {"ok": False, "message": "Username already exists"}
@@ -208,6 +213,15 @@ async def update_user_role(
             "UPDATE users SET role = ?, token_version = token_version + 1, updated_at = datetime('now') WHERE id = ?",
             (role, user_id),
         )
+        if role == "admin":
+            # Admin is the explicit global bypass; it needs no membership row.
+            libraries.remove_membership(db, libraries.DEFAULT_LIBRARY_ID, user_id)
+        else:
+            # Preserve the existing user-management contract for Main Library.
+            # Memberships in every other library remain independent.
+            libraries.set_membership(
+                db, libraries.DEFAULT_LIBRARY_ID, user_id, role
+            )
 
     logger.info("User id=%d role changed to '%s' by user '%s'", user_id, role, current_user["username"])
     return {"ok": True, "message": "Role updated — user's sessions have been invalidated"}

--- a/app/services/item_write.py
+++ b/app/services/item_write.py
@@ -58,7 +58,7 @@ from typing import Any, Iterable, Mapping
 from app.config import MEDIA_TYPES
 from app.database import get_game_platforms
 from app.services import isbn as isbn_svc
-from app.services import item_copies
+from app.services import item_copies, libraries
 from app.services.write_targets import (  # noqa: F401 — re-exported
     ItemValueError,
     UnknownLocationError,
@@ -280,6 +280,7 @@ def insert_item(db, fields: Mapping[str, Any] | None = None, **kwargs) -> int:
         [values[n] for n in names],
     )
     item_id = cursor.lastrowid
+    libraries.assign_item(db, item_id, libraries.DEFAULT_LIBRARY_ID)
     if "location_id" in values:
         item_copies.sync_primary_location(db, item_id, values["location_id"])
     return item_id

--- a/app/services/libraries.py
+++ b/app/services/libraries.py
@@ -1,0 +1,150 @@
+"""First-class Shelf libraries and per-library catalogue permissions.
+
+Schema ownership lives in :mod:`app.database`; this service is deliberately
+query/policy-only so permission checks never execute DDL on request paths.
+"""
+
+from __future__ import annotations
+
+
+LIBRARY_ROLE_LEVELS = {"viewer": 1, "editor": 2, "admin": 3}
+DEFAULT_LIBRARY_ID = 1
+DEFAULT_LIBRARY_NAME = "Main Library"
+
+
+def list_libraries(db, *, include_archived: bool = False) -> list[dict]:
+    where = "" if include_archived else "WHERE is_archived = 0"
+    rows = db.execute(
+        f"SELECT id, name, description, is_archived, created_at, updated_at "
+        f"FROM libraries {where} ORDER BY name COLLATE NOCASE"
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def create_library(db, name: str, description: str | None = None) -> dict:
+    clean_name = str(name or "").strip()
+    if not clean_name:
+        raise ValueError("Library name is required")
+    if len(clean_name) > 200:
+        raise ValueError("Library name is too long")
+    clean_description = str(description).strip() if description is not None else None
+    if clean_description == "":
+        clean_description = None
+    if clean_description and len(clean_description) > 2000:
+        raise ValueError("Library description is too long")
+
+    cursor = db.execute(
+        "INSERT INTO libraries (name, description) VALUES (?, ?)",
+        (clean_name, clean_description),
+    )
+    row = db.execute(
+        "SELECT id, name, description, is_archived, created_at, updated_at "
+        "FROM libraries WHERE id = ?",
+        (cursor.lastrowid,),
+    ).fetchone()
+    return dict(row)
+
+
+def set_membership(db, library_id: int, user_id: int, role: str) -> dict:
+    """Grant or change a non-admin library membership."""
+    if role not in ("viewer", "editor"):
+        raise ValueError("Library role must be viewer or editor")
+    if not db.execute("SELECT 1 FROM libraries WHERE id = ?", (library_id,)).fetchone():
+        raise LookupError("Library not found")
+    if not db.execute("SELECT 1 FROM users WHERE id = ?", (user_id,)).fetchone():
+        raise LookupError("User not found")
+
+    db.execute(
+        """INSERT INTO library_memberships (library_id, user_id, role)
+           VALUES (?, ?, ?)
+           ON CONFLICT(library_id, user_id) DO UPDATE SET
+               role = excluded.role,
+               updated_at = datetime('now')""",
+        (library_id, user_id, role),
+    )
+    row = db.execute(
+        "SELECT library_id, user_id, role, created_at, updated_at "
+        "FROM library_memberships WHERE library_id = ? AND user_id = ?",
+        (library_id, user_id),
+    ).fetchone()
+    return dict(row)
+
+
+def remove_membership(db, library_id: int, user_id: int) -> None:
+    db.execute(
+        "DELETE FROM library_memberships WHERE library_id = ? AND user_id = ?",
+        (library_id, user_id),
+    )
+
+
+def membership_role(db, user: dict, library_id: int) -> str | None:
+    """Return the effective role for one library.
+
+    ``admin`` is the only global catalogue privilege. Non-admin global roles
+    are intentionally ignored here once memberships exist; they are migration
+    input, not a permanent permission ceiling.
+    """
+    if user.get("role") == "admin":
+        return "admin"
+    row = db.execute(
+        "SELECT role FROM library_memberships WHERE library_id = ? AND user_id = ?",
+        (library_id, int(user["id"])),
+    ).fetchone()
+    return row["role"] if row else None
+
+
+def has_library_role(db, user: dict, library_id: int, minimum_role: str = "viewer") -> bool:
+    if minimum_role not in LIBRARY_ROLE_LEVELS:
+        raise ValueError("Unknown library role")
+    effective = membership_role(db, user, library_id)
+    return LIBRARY_ROLE_LEVELS.get(effective, 0) >= LIBRARY_ROLE_LEVELS[minimum_role]
+
+
+def accessible_library_ids(db, user: dict, *, include_archived: bool = False) -> list[int]:
+    """Return libraries visible to a user in stable name order."""
+    archived_clause = "" if include_archived else "AND l.is_archived = 0"
+    if user.get("role") == "admin":
+        rows = db.execute(
+            "SELECT l.id FROM libraries l WHERE 1=1 "
+            f"{archived_clause} ORDER BY l.name COLLATE NOCASE"
+        ).fetchall()
+    else:
+        rows = db.execute(
+            "SELECT l.id FROM libraries l "
+            "JOIN library_memberships lm ON lm.library_id = l.id "
+            "WHERE lm.user_id = ? "
+            f"{archived_clause} ORDER BY l.name COLLATE NOCASE",
+            (int(user["id"]),),
+        ).fetchall()
+    return [int(row["id"]) for row in rows]
+
+
+def assign_item(db, item_id: int, library_id: int) -> None:
+    """Assign or move one catalogue item to exactly one Shelf library."""
+    if not db.execute("SELECT 1 FROM items WHERE id = ?", (item_id,)).fetchone():
+        raise LookupError("Item not found")
+    if not db.execute("SELECT 1 FROM libraries WHERE id = ?", (library_id,)).fetchone():
+        raise LookupError("Library not found")
+    db.execute(
+        """INSERT INTO library_items (item_id, library_id) VALUES (?, ?)
+           ON CONFLICT(item_id) DO UPDATE SET library_id = excluded.library_id""",
+        (item_id, library_id),
+    )
+
+
+def item_library_id(db, item_id: int) -> int | None:
+    row = db.execute(
+        "SELECT library_id FROM library_items WHERE item_id = ?",
+        (item_id,),
+    ).fetchone()
+    return int(row["library_id"]) if row else None
+
+
+def has_item_role(db, user: dict, item_id: int, minimum_role: str = "viewer") -> bool:
+    """Check item access, denying unmapped items to non-admins by default."""
+    if user.get("role") == "admin":
+        return bool(db.execute("SELECT 1 FROM items WHERE id = ?", (item_id,)).fetchone())
+    library_id = item_library_id(db, item_id)
+    if library_id is None:
+        return False
+    return has_library_role(db, user, library_id, minimum_role)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,14 +206,32 @@ def viewer_client(client, viewer_user):
     return client
 
 
-def _insert_item(db, title="Test Book", isbn="9780000000026", media_type="book", **kwargs):
-    """Insert a test item and return its ID."""
+def _insert_item(
+    db,
+    title="Test Book",
+    isbn="9780000000026",
+    media_type="book",
+    _library_id=1,
+    **kwargs,
+):
+    """Insert a test item, defaulting to Main Library when libraries exist."""
     fields = {"title": title, "isbn": isbn, "media_type": media_type, "source": "test"}
     fields.update(kwargs)
     cols = ", ".join(fields.keys())
     placeholders = ", ".join("?" for _ in fields)
     cursor = db.execute(f"INSERT INTO items ({cols}) VALUES ({placeholders})", list(fields.values()))
-    return cursor.lastrowid
+    item_id = cursor.lastrowid
+    if _library_id is not None:
+        try:
+            exists = db.execute(
+                "SELECT 1 FROM libraries WHERE id = ?", (int(_library_id),)
+            ).fetchone()
+        except sqlite3.OperationalError:
+            exists = None
+        if exists:
+            from app.services import libraries
+            libraries.assign_item(db, item_id, int(_library_id))
+    return item_id
 
 
 def _insert_borrower(db, name="Test Borrower"):

--- a/tests/test_library_permissions.py
+++ b/tests/test_library_permissions.py
@@ -1,0 +1,241 @@
+"""Tests for first-class Shelf libraries and their permission boundary."""
+
+from app import database
+from app.auth import hash_password
+from app.services import libraries
+from tests.conftest import _insert_item
+
+
+def _user(db, username: str, role: str = "viewer") -> dict:
+    cursor = db.execute(
+        "INSERT INTO users (username, password, display_name, role) VALUES (?, ?, ?, ?)",
+        (username, hash_password("password123"), username.title(), role),
+    )
+    return {
+        "id": cursor.lastrowid,
+        "username": username,
+        "display_name": username.title(),
+        "role": role,
+    }
+
+
+def _migration_sql(version: int) -> str:
+    return next(
+        sql
+        for number, _description, sql in database.MIGRATIONS
+        if number == version
+    )
+
+
+def _run_upgrade_snapshot(db) -> None:
+    for version in (36, 37, 38):
+        db.execute(_migration_sql(version))
+
+
+def test_library_migrations_follow_current_upstream_namespace():
+    assert [
+        version for version, _description, _sql in database.MIGRATIONS
+        if 33 <= version <= 40
+    ] == list(range(33, 41))
+
+
+def test_init_creates_default_main_library(db):
+    rows = libraries.list_libraries(db)
+
+    main = next(row for row in rows if row["id"] == libraries.DEFAULT_LIBRARY_ID)
+    assert main["name"] == "Main Library"
+    assert main["is_archived"] == 0
+
+
+def test_upgrade_snapshot_preserves_existing_single_library_access(db):
+    viewer = _user(db, "legacy-viewer", "viewer")
+    editor = _user(db, "legacy-editor", "editor")
+    admin = _user(db, "legacy-admin", "admin")
+    item_id = _insert_item(db, title="Legacy Catalogue Item")
+
+    # Re-run only the idempotent data migrations as if these rows existed at
+    # upgrade time. Existing upstream installations should wake up as one Main Library.
+    _run_upgrade_snapshot(db)
+
+    assert libraries.item_library_id(db, item_id) == libraries.DEFAULT_LIBRARY_ID
+    assert libraries.membership_role(db, viewer, libraries.DEFAULT_LIBRARY_ID) == "viewer"
+    assert libraries.membership_role(db, editor, libraries.DEFAULT_LIBRARY_ID) == "editor"
+    # Admins need no membership row; their site role is the explicit bypass.
+    assert libraries.membership_role(db, admin, libraries.DEFAULT_LIBRARY_ID) == "admin"
+    assert db.execute(
+        "SELECT 1 FROM library_memberships WHERE user_id = ?", (admin["id"],)
+    ).fetchone() is None
+
+
+def test_library_role_is_independent_of_legacy_global_viewer_role(db):
+    user = _user(db, "mixed-access", "viewer")
+    books = libraries.create_library(db, "Books")
+    private = libraries.create_library(db, "Private Archive")
+
+    libraries.set_membership(db, books["id"], user["id"], "editor")
+    libraries.set_membership(db, private["id"], user["id"], "viewer")
+
+    assert libraries.membership_role(db, user, books["id"]) == "editor"
+    assert libraries.has_library_role(db, user, books["id"], "editor") is True
+    assert libraries.has_library_role(db, user, private["id"], "viewer") is True
+    assert libraries.has_library_role(db, user, private["id"], "editor") is False
+
+
+def test_no_membership_means_no_library_or_item_access(db):
+    user = _user(db, "no-access", "editor")
+    private = libraries.create_library(db, "Restricted")
+    item_id = _insert_item(db, title="Restricted Item", isbn="9780000007716")
+    libraries.assign_item(db, item_id, private["id"])
+
+    # The old global editor role must not leak access once library permissions
+    # are authoritative.
+    assert libraries.membership_role(db, user, private["id"]) is None
+    assert libraries.has_library_role(db, user, private["id"], "viewer") is False
+    assert libraries.has_item_role(db, user, item_id, "viewer") is False
+    assert private["id"] not in libraries.accessible_library_ids(db, user)
+
+
+def test_global_admin_can_recover_every_library_and_mapped_or_unmapped_item(db):
+    admin = _user(db, "site-admin", "admin")
+    first = libraries.create_library(db, "First")
+    second = libraries.create_library(db, "Second")
+    mapped = _insert_item(db, title="Mapped", isbn="9780000007723")
+    unmapped = _insert_item(db, title="Unmapped", isbn="9780000007730")
+    libraries.assign_item(db, mapped, first["id"])
+
+    assert libraries.has_library_role(db, admin, first["id"], "editor") is True
+    assert libraries.has_library_role(db, admin, second["id"], "viewer") is True
+    assert libraries.has_item_role(db, admin, mapped, "editor") is True
+    assert libraries.has_item_role(db, admin, unmapped, "viewer") is True
+    accessible = libraries.accessible_library_ids(db, admin)
+    assert first["id"] in accessible
+    assert second["id"] in accessible
+
+
+def test_assigning_item_to_another_library_moves_instead_of_duplicates(db):
+    first = libraries.create_library(db, "Library A")
+    second = libraries.create_library(db, "Library B")
+    item_id = _insert_item(db, title="Movable Item", isbn="9780000007747")
+
+    libraries.assign_item(db, item_id, first["id"])
+    assert libraries.item_library_id(db, item_id) == first["id"]
+
+    libraries.assign_item(db, item_id, second["id"])
+    assert libraries.item_library_id(db, item_id) == second["id"]
+    assert db.execute(
+        "SELECT COUNT(*) AS c FROM library_items WHERE item_id = ?", (item_id,)
+    ).fetchone()["c"] == 1
+
+
+def test_removing_membership_revokes_access_without_touching_catalogue(db):
+    user = _user(db, "revoked", "viewer")
+    library = libraries.create_library(db, "Shared")
+    item_id = _insert_item(db, title="Still Here", isbn="9780000007754")
+    libraries.assign_item(db, item_id, library["id"])
+    libraries.set_membership(db, library["id"], user["id"], "viewer")
+
+    assert libraries.has_item_role(db, user, item_id) is True
+    libraries.remove_membership(db, library["id"], user["id"])
+
+    assert libraries.has_item_role(db, user, item_id) is False
+    assert db.execute("SELECT title FROM items WHERE id = ?", (item_id,)).fetchone()["title"] == "Still Here"
+
+
+
+def test_new_viewer_and_editor_users_receive_main_library_membership(admin_client, db):
+    for username, role in (("new-viewer", "viewer"), ("new-editor", "editor")):
+        response = admin_client.post(
+            "/api/users",
+            data={
+                "username": username,
+                "display_name": username,
+                "password": "password123",
+                "role": role,
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["ok"] is True
+        user_id = db.execute(
+            "SELECT id FROM users WHERE username = ?", (username,)
+        ).fetchone()["id"]
+        assert libraries.membership_role(
+            db,
+            {"id": user_id, "role": role},
+            libraries.DEFAULT_LIBRARY_ID,
+        ) == role
+
+
+def test_global_role_change_keeps_main_membership_compatible(admin_client, db):
+    created = admin_client.post(
+        "/api/users",
+        data={
+            "username": "role-change",
+            "display_name": "Role Change",
+            "password": "password123",
+            "role": "viewer",
+        },
+    )
+    assert created.json()["ok"] is True
+    user_id = db.execute(
+        "SELECT id FROM users WHERE username = 'role-change'"
+    ).fetchone()["id"]
+
+    promoted = admin_client.post(
+        f"/api/users/{user_id}/role", data={"role": "editor"}
+    )
+    assert promoted.json()["ok"] is True
+    assert libraries.membership_role(
+        db, {"id": user_id, "role": "editor"}, libraries.DEFAULT_LIBRARY_ID
+    ) == "editor"
+
+    other = libraries.create_library(db, "Role-independent Library")
+    libraries.set_membership(db, other["id"], user_id, "viewer")
+    db.commit()
+
+    made_admin = admin_client.post(
+        f"/api/users/{user_id}/role", data={"role": "admin"}
+    )
+    assert made_admin.json()["ok"] is True
+    assert db.execute(
+        "SELECT 1 FROM library_memberships WHERE library_id = ? AND user_id = ?",
+        (libraries.DEFAULT_LIBRARY_ID, user_id),
+    ).fetchone() is None
+    assert db.execute(
+        "SELECT role FROM library_memberships WHERE library_id = ? AND user_id = ?",
+        (other["id"], user_id),
+    ).fetchone()["role"] == "viewer"
+
+    demoted = admin_client.post(
+        f"/api/users/{user_id}/role", data={"role": "viewer"}
+    )
+    assert demoted.json()["ok"] is True
+    assert libraries.membership_role(
+        db, {"id": user_id, "role": "viewer"}, libraries.DEFAULT_LIBRARY_ID
+    ) == "viewer"
+    assert db.execute(
+        "SELECT role FROM library_memberships WHERE library_id = ? AND user_id = ?",
+        (other["id"], user_id),
+    ).fetchone()["role"] == "viewer"
+
+
+def test_normal_item_write_assigns_new_item_to_main_library(db):
+    from app.services import item_write
+
+    item_id = item_write.insert_item(
+        db,
+        title="Default library item",
+        isbn="9780000000170",
+        media_type="book",
+        source="test",
+    )
+    assert libraries.item_library_id(db, item_id) == libraries.DEFAULT_LIBRARY_ID
+
+
+def test_fixture_can_still_create_explicitly_unmapped_item(db):
+    item_id = _insert_item(
+        db,
+        title="Deliberately unmapped",
+        isbn="9780000000194",
+        _library_id=None,
+    )
+    assert libraries.item_library_id(db, item_id) is None


### PR DESCRIPTION
## Summary

Adds the foundation for first-class Shelf libraries and per-library permissions.

- adds `libraries`, `library_memberships`, and `library_items`
- creates a default Main Library during upgrade
- assigns existing catalogue items to Main Library
- seeds existing viewer/editor users with equivalent Main Library memberships
- keeps administrators as the explicit global bypass
- gives each catalogue item exactly one library
- adds reusable service helpers for library and item permission checks
- keeps new item creation and user-role changes compatible with the default Main Library

This is intentionally a foundation PR. Browse/search scoping and the remaining item-level read/write permission enforcement are being kept as focused follow-up changes.

## Compatibility

Existing installations retain their current single-library behaviour after migration: existing items and non-admin users are mapped into Main Library automatically.

## Tests

The final branch passed:
- 2,996 unit tests
- 230 Chromium E2E tests
- focused library permission tests
- static/check suites